### PR TITLE
Add the latest version to maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.16</version>
                 <configuration>
                     <forkMode>always</forkMode>
                 </configuration>
@@ -174,6 +175,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>


### PR DESCRIPTION
Perhaps they had been declared by Jenkins project so far.
This patch prevents warning.
