### PR TITLE
Change return type

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEvent.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEvent.java
@@ -33,7 +33,7 @@ public interface GerritEvent {
      * Returns what type of event it is.
      * @return the event type.
      */
-    GerritEventType getEventType();
+    String getEventType();
 
     /**
      * Returns if a score (code review or verify) can be submitted to Gerrit.

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/ChangeAbandoned.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/ChangeAbandoned.java
@@ -73,8 +73,8 @@ public class ChangeAbandoned extends ChangeBasedEvent {
     }
 
     @Override
-    public GerritEventType getEventType() {
-        return GerritEventType.CHANGE_ABANDONED;
+    public String getEventType() {
+        return GerritEventType.CHANGE_ABANDONED.getTypeValue();
     }
 
     @Override

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/ChangeMerged.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/ChangeMerged.java
@@ -55,8 +55,8 @@ public class ChangeMerged extends ChangeBasedEvent {
     }
 
     @Override
-    public GerritEventType getEventType() {
-        return GerritEventType.CHANGE_MERGED;
+    public String getEventType() {
+        return GerritEventType.CHANGE_MERGED.getTypeValue();
     }
 
     @Override

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/ChangeRestored.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/ChangeRestored.java
@@ -72,8 +72,8 @@ public class ChangeRestored extends ChangeBasedEvent {
     }
 
     @Override
-    public GerritEventType getEventType() {
-        return GerritEventType.CHANGE_RESTORED;
+    public String getEventType() {
+        return GerritEventType.CHANGE_RESTORED.getTypeValue();
     }
 
     @Override

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/CommentAdded.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/CommentAdded.java
@@ -43,8 +43,8 @@ public class CommentAdded extends ChangeBasedEvent {
     private List<Approval> approvals = new ArrayList<Approval>();
 
     @Override
-    public GerritEventType getEventType() {
-        return GerritEventType.COMMENT_ADDED;
+    public String getEventType() {
+        return GerritEventType.COMMENT_ADDED.getTypeValue();
     }
 
     /**

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/DraftPublished.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/DraftPublished.java
@@ -42,8 +42,8 @@ public class DraftPublished extends ChangeBasedEvent {
     private transient Account uploader;
 
     @Override
-    public GerritEventType getEventType() {
-        return GerritEventType.DRAFT_PUBLISHED;
+    public String getEventType() {
+        return GerritEventType.DRAFT_PUBLISHED.getTypeValue();
     }
 
     @Override

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/PatchsetCreated.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/PatchsetCreated.java
@@ -43,8 +43,8 @@ public class PatchsetCreated extends ChangeBasedEvent {
     private transient Account uploader;
 
     @Override
-    public GerritEventType getEventType() {
-        return GerritEventType.PATCHSET_CREATED;
+    public String getEventType() {
+        return GerritEventType.PATCHSET_CREATED.getTypeValue();
     }
 
     @Override

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/RefReplicated.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/RefReplicated.java
@@ -57,8 +57,8 @@ public class RefReplicated extends GerritTriggeredEvent {
     private String targetNode;
 
     @Override
-    public GerritEventType getEventType() {
-        return GerritEventType.REF_REPLICATED;
+    public String getEventType() {
+        return GerritEventType.REF_REPLICATED.getTypeValue();
     }
 
     @Override

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/RefReplicationDone.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/RefReplicationDone.java
@@ -52,8 +52,8 @@ public class RefReplicationDone extends GerritTriggeredEvent {
     private int nodesCount;
 
     @Override
-    public GerritEventType getEventType() {
-        return GerritEventType.REF_REPLICATION_DONE;
+    public String getEventType() {
+        return GerritEventType.REF_REPLICATION_DONE.getTypeValue();
     }
 
     @Override

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/RefUpdated.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/RefUpdated.java
@@ -61,8 +61,8 @@ public class RefUpdated extends GerritTriggeredEvent {
     }
 
     @Override
-    public GerritEventType getEventType() {
-        return GerritEventType.REF_UPDATED;
+    public String getEventType() {
+        return GerritEventType.REF_UPDATED.getTypeValue();
     }
 
     @Override

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/RefReplicatedTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/RefReplicatedTest.java
@@ -45,7 +45,7 @@ public class RefReplicatedTest {
     @Test
     public void shouldBeRefReplicatedAsEventType() {
         RefReplicated refReplicated = new RefReplicated();
-        assertEquals(GerritEventType.REF_REPLICATED, refReplicated.getEventType());
+        assertEquals(GerritEventType.REF_REPLICATED.getTypeValue(), refReplicated.getEventType());
     }
 
     /**

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/RefReplicationDoneTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/RefReplicationDoneTest.java
@@ -45,7 +45,7 @@ public class RefReplicationDoneTest {
     @Test
     public void shouldBeRefReplicationDoneAsEventType() {
         RefReplicationDone refReplicationDone = new RefReplicationDone();
-        assertEquals(GerritEventType.REF_REPLICATION_DONE, refReplicationDone.getEventType());
+        assertEquals(GerritEventType.REF_REPLICATION_DONE.getTypeValue(), refReplicationDone.getEventType());
     }
 
     /**


### PR DESCRIPTION
The return type of GerritEvent#getEventType() is GerritEventType.
Unfortunately we need to update this type if we want to add event types.

This patch changes return type to String.

This would allow external module adding handled event using
GerritJsonEvent　extended class.
