### PR TITLE
Fix an issue related to Watchdog reconnection.

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
@@ -332,6 +332,8 @@ public class GerritConnection extends Thread implements Connector {
                 } while (line != null);
             } catch (IOException ex) {
                 logger.error("Stream events command error. ", ex);
+            } catch (IllegalStateException ex) {
+                logger.error("Unexpected disconnection occurred after initial moment of connection. ", ex);
             } finally {
                 logger.trace("Connection closed, ended read loop.");
                 nullifyWatchdog();


### PR DESCRIPTION
Add a catch statement to handle the IllegalStateException being
thrown by SshConnection in very specific circumstances. If a
disconnection would occur during the short timeframe between
connecting (calling of the connect() method in GerritConnection.java)
and the moment when the ssh command is executed by the
executeCommandReader() method, the watchdog would stop trying to
reconnect to gerrit. This issue has occurred several times and
caused problems for Jenkins builds which depend on projects in Gerrit.
When caught, the exception no longer causes a reconnection issue.

The fix was tested in multiple test environments by setting a
breakpoint at the specific moment when the issue was occurring,
forcing a disconnection via failover, and observing the Watchdog's
reconnection process.
