### PR TITLE
Add new interface and class for send command

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritCmdRunner2.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritCmdRunner2.java
@@ -33,7 +33,6 @@ public interface GerritCmdRunner2 extends GerritCmdRunner {
     /**
      * Runs a command on the gerrit server.
      * @param command the command.
-     * @return true if the command was successful, false otherwise.
      * @throws IOException if error.
      * @throws InterruptedException if interrupted.
      */

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/workers/cmd/AbstractSendCommandJob.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/workers/cmd/AbstractSendCommandJob.java
@@ -46,7 +46,7 @@ public abstract class AbstractSendCommandJob implements Runnable, GerritCmdRunne
      */
     protected static Logger logger = LoggerFactory.getLogger(AbstractSendCommandJob.class);
 
-    protected GerritConnectionConfig2 config;
+    private GerritConnectionConfig2 config;
 
     /**
      * Standard constructor taking the latest configuration.

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/workers/cmd/AbstractSendCommandJob2.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/workers/cmd/AbstractSendCommandJob2.java
@@ -27,6 +27,7 @@ package com.sonymobile.tools.gerrit.gerritevents.workers.cmd;
 import java.io.IOException;
 
 import com.sonymobile.tools.gerrit.gerritevents.GerritCmdRunner2;
+import com.sonymobile.tools.gerrit.gerritevents.GerritConnectionConfig;
 import com.sonymobile.tools.gerrit.gerritevents.GerritConnectionConfig2;
 import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnection;
 import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnectionFactory;
@@ -50,50 +51,12 @@ public abstract class AbstractSendCommandJob2 extends AbstractSendCommandJob imp
     /**
      * Sends a command to the Gerrit server.
      * @param command the command.
-     * @return true if there were no exceptions when sending.
-     */
-    @Override
-    public boolean sendCommand(String command) {
-        try {
-            SshConnection ssh = SshConnectionFactory.getConnection(config.getGerritHostName(),
-                    config.getGerritSshPort(), config.getGerritProxy(), config.getGerritAuthentication());
-            ssh.executeCommand(command);
-            ssh.disconnect();
-            return true;
-        } catch (Exception ex) {
-            logger.error("Could not run command " + command, ex);
-            return false;
-        }
-    }
-
-    /**
-     * Sends a command to the Gerrit server, returning the output from the command.
-     * @param command the command.
-     * @return the output from the command.
-     */
-    @Override
-    public String sendCommandStr(String command) {
-        try {
-            SshConnection ssh = SshConnectionFactory.getConnection(config.getGerritHostName(),
-                    config.getGerritSshPort(), config.getGerritProxy(), config.getGerritAuthentication());
-            String str = ssh.executeCommand(command);
-            ssh.disconnect();
-            return str;
-        } catch (Exception ex) {
-            logger.error("Could not run command " + command, ex);
-            return null;
-        }
-    }
-
-    /**
-     * Sends a command to the Gerrit server.
-     * @param command the command.
-     * @return true if there were no exceptions when sending.
      * @throws IOException if error.
      * @throws InterruptedException if interrupted.
      */
     @Override
     public void sendCommand2(String command) throws IOException, InterruptedException {
+        GerritConnectionConfig config = getConfig();
         SshConnection ssh = null;
         try {
             ssh = SshConnectionFactory.getConnection(config.getGerritHostName(),
@@ -113,13 +76,15 @@ public abstract class AbstractSendCommandJob2 extends AbstractSendCommandJob imp
     }
 
     /**
-     * Sends a command to the Gerrit server, returning the output from the command.
-     * This is blocking method until command is actually sent or intrrupted.
+     * Runs a command on the gerrit server and returns the output from the command.
+     * @param command the command.
+     * @return the output of the command, or null if something went wrong.
      * @throws IOException if error.
      * @throws InterruptedException if interrupted.
      */
     @Override
     public String sendCommandStr2(String command) throws IOException, InterruptedException {
+        GerritConnectionConfig config = getConfig();
         String str = null;
         SshConnection ssh = null;
         try {


### PR DESCRIPTION
Sending command job is giving up if command cannot be sent with any
reason. It means that command would be lost if Gerrit is down.

This patch adds new class and interface to raise exception if command
was not sent with errors. Also thread interrupted.
User can implement retry logic using this.
