### PR TITLE
Add abstract classes for command job based on Callable

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/workers/cmd/AbstractSendCommandJob2.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/workers/cmd/AbstractSendCommandJob2.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 rinrinne a.k.a. rin_ne All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonymobile.tools.gerrit.gerritevents.workers.cmd;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import com.sonymobile.tools.gerrit.gerritevents.GerritConnectionConfig2;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnection;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnectionFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An abstract Job implementation
+ * to be scheduled on {@link com.sonymobile.tools.gerrit.gerritevents.GerritSendCommandQueue}.
+ *
+ * @author rinrinne (rinrin.ne@gmail.com)
+ */
+public abstract class AbstractSendCommandJob2 implements Callable<String> {
+
+    /**
+     * An instance of a logger for sub-classes to use.
+     */
+    protected static Logger logger = LoggerFactory.getLogger(AbstractSendCommandJob2.class);
+
+    /**
+     * The Gerrit hostname.
+     */
+    protected final String host;
+    /**
+     * The Gerrit SSH port.
+     */
+    protected final int port;
+    /**
+     * The proxy for Gerrit SSH.
+     */
+    protected final String proxy;
+    /**
+     * The authentication for Gerrit.
+     */
+    protected final Authentication auth;
+
+    /**
+     * Standard constructor taking the latest configuration.
+     * @param config the connection config.
+     */
+    protected AbstractSendCommandJob2(GerritConnectionConfig2 config) {
+        this.host = config.getGerritHostName();
+        this.port = config.getGerritSshPort();
+        this.proxy = config.getGerritProxy();
+        this.auth = config.getGerritAuthentication();
+    }
+
+    /**
+     * Creates Gerrit command.
+     * @return the Gerrit command.
+     */
+    protected abstract String createGerritCommand();
+
+    @Override
+    public String call() throws IOException {
+        String str = null;
+        SshConnection ssh = null;
+        try {
+            ssh = SshConnectionFactory.getConnection(host, port, proxy, auth);
+            str = ssh.executeCommand(createGerritCommand());
+        } catch (Exception ex) {
+            throw new IOException("Error during sending command", ex);
+        } finally {
+            if (ssh != null) {
+                ssh.disconnect();
+            }
+        }
+        return str;
+    }
+}

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/workers/rest/AbstractRestCommandJob2.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/workers/rest/AbstractRestCommandJob2.java
@@ -1,0 +1,213 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2014 rinrinne a.k.a. rin_ne All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.tools.gerrit.gerritevents.workers.rest;
+
+import com.google.gson.Gson;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.rest.ChangeId;
+import com.sonymobile.tools.gerrit.gerritevents.dto.rest.ReviewInput;
+import com.sonymobile.tools.gerrit.gerritevents.rest.RestConnectionConfig;
+
+import org.apache.http.HttpStatus;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.Callable;
+
+/**
+ * An abstract Job implementation
+ * to be scheduled on {@link com.sonymobile.tools.gerrit.gerritevents.GerritSendCommandQueue}.
+ *
+ * @author rinrinne (rinrin.ne@gmail.com)
+ */
+public abstract class AbstractRestCommandJob2 implements Callable<String> {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractRestCommandJob2.class);
+
+    /**
+     * The GSON API.
+     */
+    private static final Gson GSON = new Gson();
+    /**
+     * The Front End URL.
+     */
+    protected final String frontEndUrl;
+    /**
+     * The HTTP proxy.
+     */
+    protected final String httpProxy;
+    /**
+     * The Credentials.
+     */
+    protected final Credentials credentials;
+    /**
+     * The listener.
+     */
+    protected final PrintStream altLogger;
+
+    /**
+     * The Event.
+     */
+    protected final ChangeBasedEvent event;
+
+    /**
+     * Constructor.
+     *
+     * @param config    config
+     * @param altLogger alternative stream to also write log output to (ex: a build log)
+     * @param event     event
+     */
+    public AbstractRestCommandJob2(RestConnectionConfig config, PrintStream altLogger, ChangeBasedEvent event) {
+        this.frontEndUrl = config.getGerritFrontEndUrl();
+        this.httpProxy = config.getGerritProxy();
+        this.credentials = config.getHttpCredentials();
+        this.altLogger = altLogger;
+        this.event = event;
+    }
+
+    @Override
+    public String call() throws IOException {
+        String response = "";
+        ReviewInput reviewInput = createReview();
+
+        String reviewEndpoint = resolveEndpointURL();
+
+        HttpPost httpPost = createHttpPostEntity(reviewInput, reviewEndpoint);
+
+        if (httpPost == null) {
+            return response;
+        }
+
+        CredentialsProvider credProvider = new BasicCredentialsProvider();
+        credProvider.setCredentials(AuthScope.ANY, credentials);
+
+        HttpHost proxy = null;
+        if (httpProxy != null && !httpProxy.isEmpty()) {
+            try {
+                URL url = new URL(httpProxy);
+                proxy = new HttpHost(url.getHost(), url.getPort(), url.getProtocol());
+            } catch (MalformedURLException e) {
+                logger.error("Could not parse proxy URL, attempting without proxy.", e);
+                if (altLogger != null) {
+                    altLogger.print("ERROR Could not parse proxy URL, attempting without proxy. "
+                            + e.getMessage());
+                }
+            }
+        }
+
+        HttpClientBuilder builder = HttpClients.custom();
+        builder.setDefaultCredentialsProvider(credProvider);
+        if (proxy != null) {
+            builder.setProxy(proxy);
+        }
+        CloseableHttpClient httpClient = builder.build();
+
+        try {
+            CloseableHttpResponse httpResponse = httpClient.execute(httpPost);
+            response = IOUtils.toString(httpResponse.getEntity().getContent(), "UTF-8");
+
+            if (httpResponse.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                logger.error("Gerrit response: {}", httpResponse.getStatusLine().getReasonPhrase());
+                if (altLogger != null) {
+                    altLogger.print("ERROR Gerrit response: " + httpResponse.getStatusLine().getReasonPhrase());
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Failed to submit result to Gerrit", e);
+            if (altLogger != null) {
+                altLogger.print("ERROR Failed to submit result to Gerrit" + e.toString());
+            }
+        }
+        return response;
+    }
+
+    /**
+     * Create the input for the command.
+     *
+     * @return the input
+     */
+    protected abstract ReviewInput createReview();
+
+    /**
+     * Construct the post.
+     *
+     * @param reviewInput    input
+     * @param reviewEndpoint end point
+     * @return the entity
+     */
+    private HttpPost createHttpPostEntity(ReviewInput reviewInput, String reviewEndpoint) {
+        HttpPost httpPost = new HttpPost(reviewEndpoint);
+
+        String asJson = GSON.toJson(reviewInput);
+
+        StringEntity entity = null;
+        try {
+            entity = new StringEntity(asJson);
+        } catch (UnsupportedEncodingException e) {
+            logger.error("Failed to create JSON for posting to Gerrit", e);
+            if (altLogger != null) {
+                altLogger.print("ERROR Failed to create JSON for posting to Gerrit: " + e.toString());
+            }
+            return null;
+        }
+        entity.setContentType("application/json");
+        httpPost.setEntity(entity);
+        return httpPost;
+    }
+
+    /**
+     * What it says resolve Endpoint URL.
+     *
+     * @return the url.
+     */
+    private String resolveEndpointURL() {
+        String gerritFrontEndUrl = frontEndUrl;
+        if (!gerritFrontEndUrl.endsWith("/")) {
+            gerritFrontEndUrl = gerritFrontEndUrl + "/";
+        }
+
+        ChangeId changeId = new ChangeId(event.getChange().getProject(), event.getChange().getBranch(),
+                event.getChange().getId());
+
+        return gerritFrontEndUrl + "a/changes/" + changeId.asUrlPart()
+                + "/revisions/" + event.getPatchSet().getRevision() + "/review";
+    }
+}

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/workers/cmd/AbstractSendCommandJob2Test.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/workers/cmd/AbstractSendCommandJob2Test.java
@@ -1,0 +1,147 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 rinrinne a.k.a. rin_ne All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonymobile.tools.gerrit.gerritevents.workers.cmd;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.sonymobile.tools.gerrit.gerritevents.GerritConnectionConfig2;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnection;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnectionFactory;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.SshException;
+
+
+
+
+// CS IGNORE AvoidStarImport FOR NEXT 4 LINES. REASON: Test code.
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Matchers.*;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Tests {@link com.sonymobile.tools.gerrit.gerritevents.workers.cmd.AbstractSendCommandJob}.
+ * @author rinrinne (rinrin.ne@gmail.com)
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(SshConnectionFactory.class)
+public class AbstractSendCommandJob2Test {
+    private static GerritConnectionConfig2 mockConfig;
+
+    //CS IGNORE MagicNumber FOR NEXT 400 LINES. REASON: Test data.
+
+    /**
+     * Setup before all tests in this class.
+     *
+     * @throws IOException if so.
+     */
+    @BeforeClass
+    public static void beforeClass() throws IOException {
+        mockConfig = mock(GerritConnectionConfig2.class);
+    }
+
+    /**
+     * Tests {@link sendCommand()}.
+     *
+     * @throws IOException if so.
+     */
+    @Test
+    public void testSendCommand() throws IOException {
+        SshConnection mockSshConnection = mock(SshConnection.class);
+        when(mockSshConnection.executeCommand(anyString())).thenReturn("OK");
+        PowerMockito.mockStatic(SshConnectionFactory.class);
+        when(SshConnectionFactory.getConnection(anyString(), anyInt(), anyString(), (Authentication)anyObject()))
+            .thenReturn(mockSshConnection);
+        AbstractSendCommandJob2 job = new AbstractSendCommandJob2Impl(mockConfig);
+        Assert.assertThat(job.call(), containsString("OK"));
+        Mockito.verify(mockSshConnection).executeCommand(anyString());
+        Mockito.verify(mockSshConnection).disconnect();
+    }
+
+    /**
+     * Tests {@link sendCommand()} without connection.
+     *
+     * @throws IOException if so.
+     */
+    @Test(expected = IOException.class)
+    public void testSendCommandNoConnection() throws IOException {
+        PowerMockito.mockStatic(SshConnectionFactory.class);
+        when(SshConnectionFactory.getConnection(anyString(), anyInt(), anyString(), (Authentication)anyObject()))
+            .thenThrow(new IOException());
+        AbstractSendCommandJob2 job = new AbstractSendCommandJob2Impl(mockConfig);
+        job.call();
+    }
+
+    /**
+     * Tests {@link sendCommand()} with error.
+     *
+     * @throws IOException if so.
+     */
+    @Test(expected = IOException.class)
+    public void testSendCommandWithError() throws IOException {
+        PowerMockito.mockStatic(SshConnectionFactory.class);
+        SshConnection mockSshConnection = mock(SshConnection.class);
+        when(mockSshConnection.executeCommand(anyString())).thenReturn("OK");
+        when(SshConnectionFactory.getConnection(anyString(), anyInt(), anyString(), (Authentication)anyObject()))
+            .thenReturn(mockSshConnection);
+        when(mockSshConnection.executeCommand(anyString())).thenThrow(new SshException());
+        AbstractSendCommandJob2 job = new AbstractSendCommandJob2Impl(mockConfig);
+        try {
+            job.call();
+        } finally {
+            Mockito.verify(mockSshConnection).executeCommand(anyString());
+            Mockito.verify(mockSshConnection).disconnect();
+        }
+    }
+
+    /**
+     * An implementation class of AbstractSendCommandJob2.
+     * @author rinrinne (rinrin.ne@gmail.com)
+     */
+    public static class AbstractSendCommandJob2Impl extends AbstractSendCommandJob2 {
+
+        /**
+         * Default constructor.
+         * @param config the config.
+         */
+        protected AbstractSendCommandJob2Impl(GerritConnectionConfig2 config) {
+            super(config);
+        }
+
+        @Override
+        protected String createGerritCommand() {
+            return "test command";
+        }
+    }
+}

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/workers/rest/AbstractRestCommandJob2Test.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/workers/rest/AbstractRestCommandJob2Test.java
@@ -1,0 +1,184 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2013 Sony Mobile Communications AB. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonymobile.tools.gerrit.gerritevents.workers.rest;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.PatchSet;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
+import com.sonymobile.tools.gerrit.gerritevents.dto.rest.ReviewInput;
+import com.sonymobile.tools.gerrit.gerritevents.rest.RestConnectionConfig;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.Test;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link AbstractRestCommandJob}.
+ *
+ * @author <a href="mailto:robert.sandell@sonymobile.com">Robert Sandell</a>
+ */
+public class AbstractRestCommandJob2Test {
+    /**
+     * Tests a standard run with a Jetty Server accepting the request.
+     *
+     * @throws Exception if so.
+     */
+    @Test
+    public void testRun() throws Exception {
+        PatchsetCreated event = new PatchsetCreated();
+        Change change = new Change();
+        change.setId("oneIdToRuleThemAll");
+        change.setProject("project");
+        change.setBranch("mastah");
+        event.setChange(change);
+        PatchSet patchSet = new PatchSet();
+        patchSet.setRevision("theOneAndOnly");
+        event.setPatchset(patchSet);
+
+        System.out.println("Creating server");
+        final Server server = new Server(0);
+
+
+        final String assertTarget = "/a/changes/project~mastah~oneIdToRuleThemAll/revisions/theOneAndOnly/review";
+        final String expectedMessage = "Hello Gerrit";
+        final String expectedLabelName = "code-review";
+        final int expectedLabelValue = 1;
+
+        TestHandler handler = new TestHandler(assertTarget);
+        server.setHandler(handler);
+        System.out.println("Starting server");
+        server.start();
+
+        AbstractRestCommandJob2 job = setupRestCommandJob2(server, event,
+                expectedMessage, expectedLabelName, expectedLabelValue);
+        try {
+            System.out.println("Running job");
+            String response = job.call();
+            assertTrue("Invalid target: " + handler.actualTarget, handler.targetOk);
+
+            JSONObject json = JSONObject.fromObject(handler.requestContent);
+            System.out.println("JSON: " + json.toString());
+            System.out.println("RESPONSE: " + response);
+            assertEquals(expectedMessage, json.getString("message"));
+            JSONObject labels = json.getJSONObject("labels");
+            assertEquals("Bad label value", expectedLabelValue, labels.getInt(expectedLabelName));
+        } finally {
+            server.stop();
+        }
+    }
+
+    /**
+     * Creates an implementation fof a job to use for testing.
+     *
+     * @param server             the server
+     * @param event              the event to send.
+     * @param expectedMessage    the message for the {@link ReviewInput}
+     * @param expectedLabelName  the label name for the {@link ReviewInput}
+     * @param expectedLabelValue the label value for the {@link ReviewInput}
+     * @return the job
+     */
+    private AbstractRestCommandJob2 setupRestCommandJob2(final Server server, final ChangeBasedEvent event,
+                                                       final String expectedMessage, final String expectedLabelName,
+                                                       final int expectedLabelValue) {
+        return new AbstractRestCommandJob2(new RestConnectionConfig() {
+            @Override
+            public String getGerritFrontEndUrl() {
+                return "http://localhost:" + server.getConnectors()[0].getLocalPort();
+            }
+
+            @Override
+            public Credentials getHttpCredentials() {
+                return new UsernamePasswordCredentials("user", "password");
+            }
+
+            @Override
+            public String getGerritProxy() {
+                return null;
+            }
+        }, null, event) {
+            @Override
+            protected ReviewInput createReview() {
+                return new ReviewInput(expectedMessage, expectedLabelName, expectedLabelValue);
+            }
+        };
+    }
+
+
+    /**
+     * A Jetty handler to accept or deny a request.
+     */
+    static class TestHandler extends AbstractHandler {
+        String assertTarget;
+        String requestContent;
+        boolean targetOk = false;
+        String actualTarget;
+
+        /**
+         * The Constructor.
+         *
+         * @param assertTarget the target url to expect and fail if not.
+         */
+        TestHandler(String assertTarget) {
+            this.assertTarget = assertTarget;
+        }
+
+        @Override
+        public void handle(String target, Request request, HttpServletRequest httpServletRequest,
+                           HttpServletResponse response)
+                throws IOException, ServletException {
+            requestContent = IOUtils.toString(httpServletRequest.getReader());
+            System.out.println("requestContent = " + requestContent);
+            actualTarget = target;
+            if (target.equals(assertTarget)) {
+                response.setContentType("application/xml;charset=utf-8");
+                response.setStatus(HttpServletResponse.SC_OK);
+                request.setHandled(true);
+                response.getWriter().println("<response>OK</response>");
+                targetOk = true;
+            } else {
+                response.setContentType("application/xml;charset=utf-8");
+                response.setStatus(HttpServletResponse.SC_EXPECTATION_FAILED);
+                request.setHandled(true);
+                response.getWriter().println("<response>This is not the resource you are looking for</response>");
+                targetOk = false;
+            }
+        }
+
+
+    }
+}


### PR DESCRIPTION
This patch adds 2 abstract classes for command job.
Those implement Callable. So user can get command response
asynchronously using Future object.

It has possibility to have something issue if both Runnable
and Callable are implemented into one class. So implemented
as new class.

In addition:
- Replace some deprecated API for HttpClient to modern API.
- Add new command job support to GerritSendCommandQueue.
