### PR TITLE
Fix behaviour of DraftPublished and ChangeMerged

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/ChangeMerged.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/ChangeMerged.java
@@ -25,10 +25,10 @@
 package com.sonymobile.tools.gerrit.gerritevents.dto.events;
 
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventType;
+import com.sonymobile.tools.gerrit.gerritevents.dto.RepositoryModifiedEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Account;
 
 import net.sf.json.JSONObject;
-
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.SUBMITTER;
 
 /**
@@ -36,7 +36,7 @@ import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.SUBMI
  *
  * @author David Pursehouse &lt;david.pursehouse@sonyericsson.com&gt;
  */
-public class ChangeMerged extends ChangeBasedEvent {
+public class ChangeMerged extends ChangeBasedEvent implements RepositoryModifiedEvent {
 
     /**
      * Default constructor.
@@ -62,6 +62,22 @@ public class ChangeMerged extends ChangeBasedEvent {
     @Override
     public boolean isScorable() {
         return false;
+    }
+
+    @Override
+    public String getModifiedProject() {
+        if (change != null) {
+            return change.getProject();
+        }
+        return null;
+    }
+
+    @Override
+    public String getModifiedRef() {
+        if (patchSet != null) {
+            return patchSet.getRef();
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/DraftPublished.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/DraftPublished.java
@@ -23,8 +23,8 @@
  */
 package com.sonymobile.tools.gerrit.gerritevents.dto.events;
 
+
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventType;
-import com.sonymobile.tools.gerrit.gerritevents.dto.RepositoryModifiedEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Account;
 import net.sf.json.JSONObject;
 
@@ -35,7 +35,7 @@ import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.UPLOA
  *
  * @author David Pursehouse &lt;david.pursehouse@sonymobile.com&gt;
  */
-public class DraftPublished extends ChangeBasedEvent implements RepositoryModifiedEvent {
+public class DraftPublished extends ChangeBasedEvent {
 
     /* Uploader has been replaced by GerritTriggeredEvent.account.
      * This allows old builds to deserialize without warnings. */
@@ -65,19 +65,4 @@ public class DraftPublished extends ChangeBasedEvent implements RepositoryModifi
         return "DraftPublished: " + change + " " + patchSet;
     }
 
-    @Override
-    public String getModifiedProject() {
-        if (change != null) {
-            return change.getProject();
-        }
-        return null;
-    }
-
-    @Override
-    public String getModifiedRef() {
-        if (patchSet != null) {
-            return patchSet.getRef();
-        }
-        return null;
-    }
 }


### PR DESCRIPTION
Draft published event should not implement RepositoryModifiedEvent since it
does not really modify the repo.

Change Merged has the potential the modify the repo so we must implement
RepositoryModifiedEvent.

[JENKINS-25047]
