### PR TITLE
Revert Draft Published change

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/DraftPublished.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/DraftPublished.java
@@ -25,9 +25,10 @@ package com.sonymobile.tools.gerrit.gerritevents.dto.events;
 
 
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventType;
+import com.sonymobile.tools.gerrit.gerritevents.dto.RepositoryModifiedEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Account;
-import net.sf.json.JSONObject;
 
+import net.sf.json.JSONObject;
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.UPLOADER;
 
 /**
@@ -35,7 +36,7 @@ import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.UPLOA
  *
  * @author David Pursehouse &lt;david.pursehouse@sonymobile.com&gt;
  */
-public class DraftPublished extends ChangeBasedEvent {
+public class DraftPublished extends ChangeBasedEvent implements RepositoryModifiedEvent {
 
     /* Uploader has been replaced by GerritTriggeredEvent.account.
      * This allows old builds to deserialize without warnings. */
@@ -50,6 +51,22 @@ public class DraftPublished extends ChangeBasedEvent {
     @Override
     public boolean isScorable() {
         return true;
+    }
+
+    @Override
+    public String getModifiedProject() {
+        if (change != null) {
+            return change.getProject();
+        }
+        return null;
+    }
+
+    @Override
+    public String getModifiedRef() {
+        if (patchSet != null) {
+            return patchSet.getRef();
+        }
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Some corner cases exist whereby a change marked as a draft
can be rebased and marked as published.

The new patchset may not have been replicated to mirror when draft
published event is sent, so we must ensure that we check for patchset
replication first.
