### PR TITLE
Correct the construction of the refname

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/attr/RefUpdate.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/attr/RefUpdate.java
@@ -201,7 +201,10 @@ public class RefUpdate implements GerritJsonDTO {
      */
     public String getRef() {
         if (refName != null) {
-            return REFS_HEADS + refName;
+            if (!refName.startsWith("refs/")) {
+                return REFS_HEADS + refName;
+            }
+            return refName;
         }
         return null;
     }


### PR DESCRIPTION
The refName that is generated for the RefUpdated event
for tags contains the prefix "refs/tags" unlike other
RefUpdated events.

This attempts to ensure that the correct RefName is always
produced.
