### PR TITLE
Fix corrupted chars while reading from utf-8 stream

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/ssh/SshConnectionImpl.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/ssh/SshConnectionImpl.java
@@ -312,7 +312,7 @@ public class SshConnectionImpl implements SshConnection {
         try {
             Channel channel = connectSession.openChannel("exec");
             ((ChannelExec)channel).setCommand(command);
-            InputStreamReader reader = new InputStreamReader(channel.getInputStream());
+            InputStreamReader reader = new InputStreamReader(channel.getInputStream(), "utf-8");
             channel.connect();
             return reader;
         } catch (JSchException ex) {


### PR DESCRIPTION
This issue was found during connecting Jira to Gerrit via Jira Gerrit
Plugin. Without charset (utf-8) specified, multi-byte chars could be
corrupted thus results in the JSON result returned from Gerrit cannot be
parsed at all.
