### PR TITLE
New eventCreatedOn attrib for GerritTriggeredEvent

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventKeys.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventKeys.java
@@ -218,6 +218,10 @@ public abstract class GerritEventKeys {
      */
     public static final String CREATED_ON = "createdOn";
     /**
+     * eventCreatedOn.
+     */
+    public static final String EVENTCREATED_ON = "eventCreatedOn";
+    /**
      * lastUpdated.
      */
     public static final String LAST_UPDATED = "lastUpdated";

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/GerritTriggeredEvent.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/GerritTriggeredEvent.java
@@ -24,12 +24,17 @@
  */
 package com.sonymobile.tools.gerrit.gerritevents.dto.events;
 
+import static com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory.getDate;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.EVENTCREATED_ON;
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.PROVIDER;
 import net.sf.json.JSONObject;
 
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritJsonEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Account;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Provider;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -55,6 +60,11 @@ public abstract class GerritTriggeredEvent implements GerritJsonEvent {
      * Time stamp when the event was received.
      */
     protected long receivedOn;
+
+    /**
+     * Gerrit server-based time stamp when the event was created by Gerrit Server.
+     */
+    protected Date eventCreatedOn;
 
     /**
      * Standard constructor, initialize the receivedOn time stamp.
@@ -108,6 +118,14 @@ public abstract class GerritTriggeredEvent implements GerritJsonEvent {
     }
 
     /**
+     * Gerrit server-based time stamp when the event was created by Gerrit Server..
+     * @return the eventCreatedOn time stamp
+     */
+    public Date getEventCreatedOn() {
+        return eventCreatedOn;
+    }
+
+    /**
      * Time stamp when the event was received.
      * @param receivedOn the receivedOn to set
      */
@@ -115,10 +133,23 @@ public abstract class GerritTriggeredEvent implements GerritJsonEvent {
         this.receivedOn = receivedOn;
     }
 
+    /**
+     * Gerrit server-based time stamp when the event was created by Gerrit Server.
+     * ONLY USE FOR UNIT TESTS!
+     * @param eventCreatedOn the eventCreatedOn to set
+     */
+    public void setEventCreatedOn(String eventCreatedOn) {
+        Long milliseconds = TimeUnit.SECONDS.toMillis(Long.parseLong(eventCreatedOn));
+        this.eventCreatedOn = new Date(milliseconds);
+    }
+
     @Override
     public void fromJson(JSONObject json) {
         if (json.containsKey(PROVIDER)) {
             provider = new Provider(json.getJSONObject(PROVIDER));
+        }
+        if (json.containsKey(EVENTCREATED_ON)) {
+            eventCreatedOn = getDate(json, EVENTCREATED_ON);
         }
     }
 }

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/EventCreatedOnTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/EventCreatedOnTest.java
@@ -1,0 +1,64 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2014 Ericsson.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+package com.sonymobile.tools.gerrit.gerritevents.dto.events;
+
+import com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory;
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by scott.hebert@ericsson.com on 12/9/14.
+ */
+public class EventCreatedOnTest {
+
+    /**
+     * Given an event in JSON format
+     * When it is converted to an Event Object
+     * Then the eventCreatedOn attribute can be parsed as a Date.
+     * @throws IOException if we cannot load json from file.
+     */
+    @Test
+    public void fromJsonShouldProvideValidDateFromEventCreatedOn() throws IOException {
+        InputStream stream = getClass().getResourceAsStream("DeserializeEventCreatedOnTest.json");
+        String json = IOUtils.toString(stream);
+        JSONObject jsonObject = JSONObject.fromObject(json);
+        GerritEvent evt = GerritJsonEventFactory.getEvent(jsonObject);
+        GerritTriggeredEvent gEvt = (GerritTriggeredEvent)evt;
+        Date dt = gEvt.getEventCreatedOn();
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        System.out.println(df.format(dt));
+        String expectDateString = "2014-12-09 09:02:52";
+        assertEquals(expectDateString, df.format(dt));
+    }
+}

--- a/src/test/resources/com/sonymobile/tools/gerrit/gerritevents/dto/events/DeserializeEventCreatedOnTest.json
+++ b/src/test/resources/com/sonymobile/tools/gerrit/gerritevents/dto/events/DeserializeEventCreatedOnTest.json
@@ -1,0 +1,11 @@
+{"type":"change-restored","change":{"project":"playback-test","branch":"master"
+,"id":"Ibafad9613934fdec650d6186dc1021bc2cf5d2f5","number":"654","subject":"Mon Dec  8 20:53:56 EST 2014"
+,"owner":{"name":"Scott","email":"scott@company.com","username":"scott"
+  },"url":"http://localhost:9090/654"
+,"commitMessage":"Mon Dec  8 20:53:56 EST 2014\n\nChange-Id: Ibafad9613934fdec650d6186dc1021bc2cf5d2f5\n"
+,"status":"NEW"},"patchSet":{"number":"1","revision":"b2b5f7c8fb8f96312d629d4d4f379f34f5b9b651"
+,"parents":["6cf2d28cc07d22a49e0e614c7bde0a4e5fd0c8f5"],"ref":"refs/changes/54/654/1"
+,"uploader":{"name":"Scott","email":"scott@company.com","username":"scott"}
+,"createdOn":1418090036,"author":{"name":"Scott","email":"scott@company.com","username":"scott"}
+,"isDraft":false,"sizeInsertions":1,"sizeDeletions":0},"restorer":{"name":"Scott"
+,"email":"scott@company.com","username":"scott"},"eventCreatedOn":1418133772}


### PR DESCRIPTION
In certain situations, it has become necessary to know
when an event was created on the Gerrit Server side.

This attribute will be available in Gerrit 2.11
