### PR TITLE
Updated com.jcraft.jsch to 0.1.51

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.50</version>
+            <version>0.1.51</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The reason for this is that communication with Gerrit might be lost under
high-load situations when using recent Java7 releases.

The issue that occurs is the "verify:false" problem outlined in the
changelog for 0.1.51:
http://www.jcraft.com/jsch/ChangeLog

The actual error that will appear runs like this:
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Feb 02, 2015 2:42:20 PM com.sonymobile.tools.gerrit.gerritevents.workers.cmd.AbstractSendCommandJob sendCommand
SEVERE: Could not run command gerrit approve 60123,1 --message 'Build Successful
[...]
https://[URL]/job/[JOB]/2502/ : SUCCESS' --verified 1 --code-review 0
java.io.IOException: Error during sending command
[...]
Caused by: com.sonymobile.tools.gerrit.gerritevents.ssh.SshException: com.jcraft.jsch.JSchException: verify: false
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

Updating to 0.1.51 fixes this issue.