### PR TITLE
Add project-created event.

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventKeys.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventKeys.java
@@ -78,6 +78,10 @@ public abstract class GerritEventKeys {
      */
     public static final String PROJECT = "project";
     /**
+     * project name.
+     */
+    public static final String PROJECT_NAME = "projectName";
+    /**
      * restorer.
      */
     public static final String RESTORER = "restorer";
@@ -129,6 +133,10 @@ public abstract class GerritEventKeys {
      * refname.
      */
     public static final String REFNAME = "refName";
+    /**
+     * HEAD reference name.
+     */
+    public static final String HEAD_NAME = "headName";
     /**
      * oldrev.
      */

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventType.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventType.java
@@ -1,8 +1,7 @@
 /*
  *  The MIT License
  *
- *  Copyright 2010 Sony Ericsson Mobile Communications. All rights reserved.
- *  Copyright 2012 Sony Mobile Communications AB. All rights reserved.
+ *  Copyright 2010 Sony Mobile Communications Inc. All rights reserved.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +32,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefReplicated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefReplicationDone;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefUpdated;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ProjectCreated;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -78,7 +78,11 @@ public enum GerritEventType {
     /**
      * A ref-replication-done event.
      */
-    REF_REPLICATION_DONE("ref-replication-done", true, RefReplicationDone.class);
+    REF_REPLICATION_DONE("ref-replication-done", true, RefReplicationDone.class),
+    /***
+     * A project-created event.
+     */
+    PROJECT_CREATED("project-created", true, ProjectCreated.class);
 
     private String typeValue;
     private boolean interesting;

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/ProjectCreated.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/ProjectCreated.java
@@ -1,0 +1,122 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2015 Sony Mobile Communications Inc. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.tools.gerrit.gerritevents.dto.events;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventType;
+import com.sonymobile.tools.gerrit.gerritevents.dto.RepositoryModifiedEvent;
+import net.sf.json.JSONObject;
+
+import static com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory.getString;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.PROJECT_NAME;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.HEAD_NAME;
+
+/**
+ * A DTO representation of the project-created Gerrit Event.
+ *
+ * @author Sven Selberg &lt;sven.selberg@sonymobile.com&gt;
+ */
+public class ProjectCreated extends GerritTriggeredEvent implements RepositoryModifiedEvent {
+
+    /**
+     * Name of the created project.
+     */
+    private String projectName;
+
+    /**
+     * HEAD reference name.
+     */
+    private String headName;
+
+    /**
+     *
+     * @return the name of HEAD.
+     */
+    public String getHeadName() {
+        return headName;
+    }
+
+    /**
+     * Sets the name of HEAD.
+     * @param headName the name of HEAD.
+     */
+    public void setHeadName(String headName) {
+        this.headName = headName;
+    }
+
+    /**
+     *
+     * @return the project name.
+     */
+    public String getProjectName() {
+        return projectName;
+    }
+
+    /**
+     * sets the project name.
+     * @param projectName the name of the project.
+     */
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
+    }
+
+    @Override
+    public void fromJson(JSONObject json) {
+        super.fromJson(json);
+        projectName = getString(json, PROJECT_NAME);
+        headName = getString(json, HEAD_NAME);
+    }
+
+    @Override
+    public GerritEventType getEventType() {
+        return GerritEventType.PROJECT_CREATED;
+    }
+
+    @Override
+    public boolean isScorable() {
+        return false;
+    }
+
+    @Override
+    public String getModifiedProject() {
+        return projectName;
+    }
+
+    @Override
+    public String getModifiedRef() {
+        return headName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) { return true; }
+        if (o == null || getClass() != o.getClass()) { return false; }
+        ProjectCreated that = (ProjectCreated)o;
+        return projectName.equals(that.projectName);
+    }
+
+    @Override
+    public int hashCode() {
+        return projectName.hashCode();
+    }
+}

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritHandlerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritHandlerTest.java
@@ -1,8 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2011 Sony Ericsson Mobile Communications. All rights reserved.
- * Copyright 2012 Sony Mobile Communications AB. All rights reserved.
+ * Copyright 2011 Sony Mobile Communications Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +33,8 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.CommentAdded;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.DraftPublished;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefUpdated;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ProjectCreated;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -364,6 +365,10 @@ public class GerritHandlerTest {
         RefUpdated refUpdated = new RefUpdated();
         handler.notifyListeners(refUpdated);
         verify(listenerMock, times(1)).gerritEvent(refUpdated);
+
+        ProjectCreated projectCreated = new ProjectCreated();
+        handler.notifyListeners(projectCreated);
+        verify(listenerMock, times(1)).gerritEvent(projectCreated);
     }
 
     /**
@@ -479,6 +484,22 @@ public class GerritHandlerTest {
     }
 
     /**
+     * Tests that ProjectCreated event are going in the method with
+     * that type as parameter and that other type of events are going
+     * in the default method.
+     */
+    @Test
+    public void testEventNotificationWithListenerProjectCreatedMethodSignature() {
+        SpecificEventListener projectCreatedListener = new SpecificEventListener() {
+            @SuppressWarnings("unused") //method is called by reflection
+            public void gerritEvent(ProjectCreated event) {
+                specificMethodCalled = true;
+            }
+        };
+        testListenerWithSpecificSignature(projectCreatedListener, new ProjectCreated());
+    }
+
+    /**
      * Base test listener implementation.
      */
     private abstract static class SpecificEventListener implements GerritEventListener {
@@ -511,7 +532,8 @@ public class GerritHandlerTest {
                                                      new ChangeAbandoned(),
                                                      new DraftPublished(),
                                                      new PatchsetCreated(),
-                                                     new RefUpdated(), };
+                                                     new RefUpdated(),
+                                                     new ProjectCreated(), };
         handler.addListener(listener);
 
         // Validate that event was sent to the specific method


### PR DESCRIPTION
This is needed to enable incremental update of the project list in Gerrit-Trigger. So that Gerrit-Trigger only does one initial load of the gerrit projects, and thereafter only listens to project-created events. This to prevent unnecessary polling of Gerrit.

I have a patch for this functionality, ready to upload to gerrit-trigger, but i need a release of the gerrit-events that supports it first.

project-created event was introduced to Gerrit with [1].

[1] https://gerrit-review.googlesource.com/#/c/67294/

Change-Id: I7badaa9dcbdbfb8c24c367d9eb6006fc6da7a192