### PR TITLE
Set publickey as PreferredAuthentications for the SSH connection

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/ssh/SshConnectionImpl.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/ssh/SshConnectionImpl.java
@@ -154,6 +154,7 @@ public class SshConnectionImpl implements SshConnection {
             }
             client.setHostKeyRepository(new BlindHostKeyRepository());
             connectSession = client.getSession(auth.getUsername(), host, port);
+            connectSession.setConfig("PreferredAuthentications", "publickey");
             if (proxy != null && !proxy.isEmpty()) {
                 String[] splitted = proxy.split(":");
                 if (splitted.length > 2 && splitted[1].length() >= PROTO_HOST_DELIM_LENGTH) {


### PR DESCRIPTION
The SSH client will try to connect using Kerberos authentication
when the server provides it. This will cause the client to wait till
Kerberos credentials have been filled in using the console.

This change will set the PreferredAuthentications setting to publickey
causing the client to only use publickey authentication.