### PR TITLE
Doc: update required java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All event types can be found in the [com.sonymobile.tools.gerrit.gerritevents.dt
 
 # Environments
 * `linux`
-    * `java-1.6`
+    * `java-1.7`
         * `maven-3.0.4`
 
 The maintainers' development, tests and production environments are


### PR DESCRIPTION
This library now requires Java 1.7 because Java java.nio.file.Files package was introduced in
Java 7. Compilers from earlier versions of the JDK will baulk at any
code that references this class.