### PR TITLE
Deprecate get updated

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventKeys.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventKeys.java
@@ -162,9 +162,9 @@ public abstract class GerritEventKeys {
      */
     public static final String VALUE = "value";
     /**
-     * approval updated.
+     * the approval's old (or previous) value.
      */
-    public static final String UPDATED = "updated";
+    public static final String OLD_VALUE = "oldValue";
     /**
      * approval by.
      */

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventKeys.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventKeys.java
@@ -162,6 +162,10 @@ public abstract class GerritEventKeys {
      */
     public static final String VALUE = "value";
     /**
+     * approval updated.
+     */
+    public static final String UPDATED = "updated";
+    /**
      * the approval's old (or previous) value.
      */
     public static final String OLD_VALUE = "oldValue";

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/attr/Approval.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/attr/Approval.java
@@ -24,14 +24,13 @@
 package com.sonymobile.tools.gerrit.gerritevents.dto.attr;
 
 import static com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory.getString;
-import static com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory.getBoolean;
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritJsonDTO;
 import net.sf.json.JSONObject;
 
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.BY;
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.TYPE;
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.VALUE;
-import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.UPDATED;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.OLD_VALUE;
 
 /**
  * Represents a Gerrit JSON Approval DTO.
@@ -49,9 +48,9 @@ public class Approval implements GerritJsonDTO {
      */
     private String value;
     /**
-     * Approval value update indicator
+     * The old (or previous) approval value
      */
-    private Boolean updated;
+    private String oldValue;
     /**
      * The user who has approved the patch
      */
@@ -91,8 +90,8 @@ public class Approval implements GerritJsonDTO {
         if (json.containsKey(BY)) {
             by = new Account(json.getJSONObject(BY));
         }
-        if (json.containsKey(UPDATED)) {
-            updated = getBoolean(json, UPDATED);
+        if (json.containsKey(OLD_VALUE)) {
+            oldValue = getString(json, OLD_VALUE);
         }
     }
 
@@ -156,13 +155,25 @@ public class Approval implements GerritJsonDTO {
     }
 
     /**
-     * The approval score updated flag.
+     * The old (or previous) approval value.
      *
-     * @return true if approval score changed, false otherwise
-     *         null if Gerrit does not support this attribute
+     * @return the old approval value.
      */
-    public Boolean getUpdated() {
-        return updated;
+    public String getOldValue() {
+        return oldValue;
+    }
+
+    /**
+     * Checks whether this approval was updated.
+     * oldValue is only set when the approval has been changed.
+     *
+     * @return true if approval was updated, otherwise false.
+     */
+    public Boolean isUpdated() {
+        if (getOldValue() != null) {
+          return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/attr/Approval.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/attr/Approval.java
@@ -24,12 +24,14 @@
 package com.sonymobile.tools.gerrit.gerritevents.dto.attr;
 
 import static com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory.getString;
+import static com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory.getBoolean;
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritJsonDTO;
 import net.sf.json.JSONObject;
 
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.BY;
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.TYPE;
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.VALUE;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.UPDATED;
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.OLD_VALUE;
 
 /**
@@ -47,6 +49,10 @@ public class Approval implements GerritJsonDTO {
      * The approval value
      */
     private String value;
+    /**
+     * Approval value update indicator
+     */
+    private Boolean updated;
     /**
      * The old (or previous) approval value
      */
@@ -89,6 +95,9 @@ public class Approval implements GerritJsonDTO {
         }
         if (json.containsKey(BY)) {
             by = new Account(json.getJSONObject(BY));
+        }
+        if (json.containsKey(UPDATED)) {
+            updated = getBoolean(json, UPDATED);
         }
         if (json.containsKey(OLD_VALUE)) {
             oldValue = getString(json, OLD_VALUE);
@@ -152,6 +161,19 @@ public class Approval implements GerritJsonDTO {
      */
     public String getValue() {
         return value;
+    }
+
+    /**
+     * The approval score updated flag.
+     *
+     *  @return true if approval score changed, false otherwise
+     *         null if Gerrit does not support this attribute
+     *
+     * @deprecated use {@link #isUpdated()} instead.
+     */
+    @Deprecated
+    public Boolean getUpdated() {
+        return updated;
     }
 
     /**


### PR DESCRIPTION
Change 3627295 prematurely added support to an unmerged
gerrit stream events change[1]. That gerrit change started
out with an updated property to indicate that an approval
was updated however thru reviews that change ended up adding
an oldValue property instead. This property is used to
show the previous approval value when the score changed. Also
the property is only appended to the stream event if the
approval was changed so we can use this info to determine
whether the approval was updated.  We also deprecate `getUpdate` in
favor of `isUpdated`.

[1] https://gerrit-review.googlesource.com/#/c/71051/