### PR TITLE
Improve SSH command stream channel handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
             <version>2.1</version>
         </dependency>
         <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-annotations</artifactId>
+            <version>1.15</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.11</version>


### PR DESCRIPTION
Hi, long time no see :)

I have had a concern about GerritConnection for a long time. Its thread is blocked by readLine(). Due to this, we had to close connection rather than channel. It made a lot of exceptions whenever disconnected.

This might solve issues around SSH connection handling.