### PR TITLE
Get out of gerrit event stream loop in illegal state

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/ssh/SshConnection.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/ssh/SshConnection.java
@@ -88,6 +88,23 @@ public interface SshConnection {
      */
     ChannelExec executeCommandChannel(String command) throws SshException, IOException;
 
+    //CS IGNORE RedundantThrows FOR NEXT 15 LINES. REASON: Informative.
+
+    /**
+     * Execute an ssh command on the server, without closing the session
+     * so that the caller can get access to all the Channel attributes from
+     * the server. If establishConnection is false, channel connection also
+     * can be handled by the server.
+     *
+     * @param command the command to execute.
+     * @param establishConnection true if establish channel connetction within this method.
+     * @return a Channel with access to all streams and the exit code.
+     * @throws IOException  if it is so.
+     * @throws SshException if there are any ssh problems.
+     * @see #executeCommandReader(String)
+     */
+    ChannelExec executeCommandChannel(String command, Boolean establishConnection) throws SshException, IOException;
+
     /**
      * Connects the connection.
      * @throws IOException if it is so.

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/ssh/SshConnectionImpl.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/ssh/SshConnectionImpl.java
@@ -335,14 +335,37 @@ public class SshConnectionImpl implements SshConnection {
      * @see #executeCommandReader(String)
      */
     @Override
-    public synchronized ChannelExec executeCommandChannel(String command) throws SshException, IOException {
+    public ChannelExec executeCommandChannel(String command) throws SshException, IOException {
+        return executeCommandChannel(command, true);
+    }
+
+    //CS IGNORE RedundantThrows FOR NEXT 17 LINES. REASON: Informative.
+
+    /**
+     * This version takes a command to run, and then returns a wrapper instance
+     * that exposes all the standard state of the channel (stdin, stdout,
+     * stderr, exit status, etc). Channel connection is established if establishConnection
+     * is true.
+     *
+     * @param command the command to execute.
+     * @param establishConnection true if establish channel connetction within this method.
+     * @return a Channel with access to all streams and the exit code.
+     * @throws IOException  if it is so.
+     * @throws SshException if there are any ssh problems.
+     * @see #executeCommandReader(String)
+     */
+    @Override
+    public synchronized ChannelExec executeCommandChannel(String command, Boolean establishConnection)
+            throws SshException, IOException {
         if (!isConnected()) {
             throw new IOException("Not connected!");
         }
         try {
             ChannelExec channel = (ChannelExec)connectSession.openChannel("exec");
             channel.setCommand(command);
-            channel.connect();
+            if (establishConnection) {
+                channel.connect();
+            }
             return channel;
         } catch (JSchException ex) {
             throw new SshException(ex);

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnectionTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnectionTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -104,6 +105,8 @@ public class GerritConnectionTest {
         ChannelExec channelExecMock = mock(ChannelExec.class);
         when(channelExecMock.isConnected()).thenReturn(true);
         when(sshConnectionMock.executeCommandChannel(eq("gerrit stream-events"))).thenReturn(channelExecMock);
+        when(sshConnectionMock.executeCommandChannel(eq("gerrit stream-events"), anyBoolean()))
+            .thenReturn(channelExecMock);
         when(channelExecMock.getInputStream()).thenReturn(pipedInStream);
         PowerMockito.mockStatic(SshConnectionFactory.class);
         PowerMockito.doReturn(sshConnectionMock).when(SshConnectionFactory.class, "getConnection",


### PR DESCRIPTION
InputStream generated by SSH channel may not reach EOF in illegal SSH connection state change. Due to this, GerritConnection cannot get out of the loop for reading gerrit stream.

This patch checks the state of SSH channel and connection per loop. In addition, send signal to watchdog only if stream read count is > 0 for working watchdog effectively.

Issue: #58 