### PR TITLE
Add 'tag' field to ReviewInput

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/rest/ReviewInput.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/rest/ReviewInput.java
@@ -44,6 +44,7 @@ public class ReviewInput {
     final Map<String, Integer> labels = new HashMap<String, Integer>();
     final Map<String, List<LineComment>> comments = new HashMap<String, List<LineComment>>();
     Notify notify;
+    String tag;
 
     /**
      * Standard Constructor.
@@ -115,6 +116,17 @@ public class ReviewInput {
      */
     public ReviewInput setNotify(Notify value) {
         this.notify = value;
+        return this;
+    }
+
+    /**
+     * Sets the 'tag' value.  Defines an optional tag to the review. This enables filtering out automatic comments.
+     *
+     * @param value the value to set.
+     * @return this instance for convenience
+     */
+    public ReviewInput setTag(String value) {
+        this.tag = value;
         return this;
     }
 }


### PR DESCRIPTION
To support setting tag to comments in the Gerrit Trigger plugin,
add the 'tag' field to ReviewInput class as specified in [1].

[1] https://gerrit-documentation.storage.googleapis.com/Documentation/2.13/rest-api-changes.html#review-input

[JENKINS-43904]