### PR TITLE
Fix [JENKINS-44568]: restore old ways of handling ssh disconnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ handler.addListener(new MyEventListener());
 
 All event types can be found in the [com.sonymobile.tools.gerrit.gerritevents.dto.events](https://github.com/sonyxperiadev/gerrit-events/tree/master/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events) package.
 
+# Configuration
+You can configure some options using java system properties. All you need is to pass `-D<OPTION_NAME>=<OPTION_VALUE>` to JVM.
+
+* `GERRIT_SSH_RX_BUFFER_SIZE` - the size of charachter buffer for ssh channel [default value: 32768 bytes]
 
 # Environments
 * `linux`

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
@@ -436,7 +436,7 @@ public class GerritConnection extends Thread implements Connector {
                 logger.error("Error when establishing SSH connection. ", ex);
             } finally {
                 nullifyWatchdog();
-                if (channel != null && !channel.isClosed()) {
+                if (channel != null) {
                     logger.trace("Close channel.");
                     try {
                         channel.disconnect();
@@ -451,7 +451,9 @@ public class GerritConnection extends Thread implements Connector {
                      logger.warn("Error when disconnecting sshConnection.", ex);
                 }
 
-                sshConnection = null;
+                if (!sshConnection.isConnected()) {
+                    sshConnection = null;
+                }
 
                 notifyConnectionDown();
             }

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
@@ -444,9 +444,15 @@ public class GerritConnection extends Thread implements Connector {
                         logger.warn("Error when disconnecting SSH command channel.", ex);
                     }
                 }
-                if (!sshConnection.isConnected()) {
-                    sshConnection = null;
+
+                try {
+                    sshConnection.disconnect();
+                } catch (Exception ex) {
+                     logger.warn("Error when disconnecting sshConnection.", ex);
                 }
+
+                sshConnection = null;
+
                 notifyConnectionDown();
             }
         } while (!shutdownInProgress);

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
@@ -69,7 +69,8 @@ public class GerritConnection extends Thread implements Connector {
      */
     public static final String CMD_STREAM_EVENTS = "gerrit stream-events";
     private static final String GERRIT_VERSION_PREFIX = "gerrit version ";
-    private static final int SSH_RX_BUFFER_SIZE = 32768;
+    private static final String SSH_RX_BUFFER_SIZE_PROPERTY_NAME = "GERRIT_SSH_RX_BUFFER_SIZE";
+    private static final int DEFAULT_SSH_RX_BUFFER_SIZE = 32768;
     private static final int SSH_RX_SLEEP_MILLIS = 100;
     /**
      * The standard scheme used for stream-events.
@@ -93,7 +94,7 @@ public class GerritConnection extends Thread implements Connector {
     private GerritHandler handler;
     private AuthenticationUpdater authenticationUpdater = null;
     private final Set<ConnectionListener> listeners = new CopyOnWriteArraySet<ConnectionListener>();
-    private int sshRxBufferSize = SSH_RX_BUFFER_SIZE;
+    private int sshRxBufferSize = getInitialSshRxBufferSize();
 
     /**
      * Creates a GerritHandler with all the default values set.
@@ -732,5 +733,20 @@ public class GerritConnection extends Thread implements Connector {
     protected void notifyConnectionEstablished() {
         connected = true;
         notifyListeners(GerritConnectionEvent.GERRIT_CONNECTION_ESTABLISHED);
+    }
+
+    /**
+     * Reads the value of {@code GERRIT_SSH_RX_BUFFER_SIZE} property provided to the java process
+     * by passing "-D{@code GERRIT_SSH_RX_BUFFER_SIZE}"
+     *
+     * @return ssh buffer size
+     */
+    private static int getInitialSshRxBufferSize() {
+        String envValue = System.getProperty(SSH_RX_BUFFER_SIZE_PROPERTY_NAME);
+        if (envValue == null) {
+            return DEFAULT_SSH_RX_BUFFER_SIZE;
+        } else {
+            return Integer.parseInt(envValue);
+        }
     }
 }

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
@@ -69,7 +69,7 @@ public class GerritConnection extends Thread implements Connector {
      */
     public static final String CMD_STREAM_EVENTS = "gerrit stream-events";
     private static final String GERRIT_VERSION_PREFIX = "gerrit version ";
-    private static final int SSH_RX_BUFFER_SIZE = 16384;
+    private static final int SSH_RX_BUFFER_SIZE = 32768;
     private static final int SSH_RX_SLEEP_MILLIS = 100;
     /**
      * The standard scheme used for stream-events.


### PR DESCRIPTION
If I understood the source code correctly, since https://github.com/sonyxperiadev/gerrit-events/commit/57163bb97b35aeb4ddf4c035692c424db71a86b8 re-connect is broken.
Because we do not "close" the sshConnection, as it was done before. So `sshConnection` object assumes that connection still exists.

As I mentioned in https://issues.jenkins-ci.org/browse/JENKINS-44568, I'm not sure that this PR really fixes the stuff, because I didn't have time to test it, so, let's wait for some feedback.