### PR TITLE
fix: JENKINS-44568, JENKINS-44414

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
@@ -448,7 +448,7 @@ public class GerritConnection extends Thread implements Connector {
                     if (!channel.isConnected() || !sshConnection.isConnected()) {
                         throw new IllegalStateException("SSH connection is already lost.");
                     }
-                    if (linecount > 0) {
+                    if (readCount == 0 || linecount > 0) {
                         sleep(SSH_RX_SLEEP_MILLIS);
                     }
                 }

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnectionTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnectionTest.java
@@ -112,6 +112,7 @@ public class GerritConnectionTest {
         PowerMockito.doReturn(sshConnectionMock).when(SshConnectionFactory.class, "getConnection",
                 isA(String.class), isA(Integer.class), isA(String.class), isA(Authentication.class), any());
         connection = new GerritConnection("", "localhost", 29418, new Authentication(null, ""));
+        connection.setSshRxBufferSize(20);
         handlerMock = mock(HandlerMock.class);
         connection.setHandler(handlerMock);
         connection.addListener(new ListenerMock());


### PR DESCRIPTION
fix: [JENKINS-44568], [JENKINS-44414]
When a message is received that is bigger than the internal buffer, the
internal buffer position was wrongly set to the buffer capacity.
But we also can't just delete the buffer is no newline was found. So we
append what we've read in a Stringbuilder and append until we encounter a
newline.