### PR TITLE
Add line oriented queue

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
@@ -28,14 +28,12 @@ package com.sonymobile.tools.gerrit.gerritevents;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.CharBuffer;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 import com.jcraft.jsch.ChannelExec;
 import com.jcraft.jsch.JSchException;
-import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +44,7 @@ import com.sonymobile.tools.gerrit.gerritevents.ssh.SshAuthenticationException;
 import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnectException;
 import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnection;
 import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnectionFactory;
+import com.sonymobile.tools.gerrit.gerritevents.util.LineQueue;
 import com.sonymobile.tools.gerrit.gerritevents.watchdog.StreamWatchdog;
 import com.sonymobile.tools.gerrit.gerritevents.watchdog.WatchTimeExceptionData;
 
@@ -328,49 +327,6 @@ public class GerritConnection extends Thread implements Connector {
     }
 
     /**
-     * Offers lines in buffer to queue.
-     *
-     * @param cb a buffer to have received text data.
-     * @return the line string. null if no EOL, otherwise buffer is compacted.
-     */
-    private String getLine(CharBuffer cb) {
-        String line = null;
-        int pos = cb.position();
-        cb.flip();
-        for (int i = 0; i < cb.length(); i++) {
-            if (cb.charAt(i) == '\n') {
-                line = getSubSequence(cb, 0, i).toString().trim();
-                cb.position(i + 1);
-                break;
-            }
-        }
-        if (line != null) {
-            cb.compact();
-        } else {
-            cb.clear().position(pos);
-        }
-        return line;
-    }
-
-    /**
-     *  Get sub sequence of buffer.
-     *
-     *  This method avoids error in java-api-check.
-     *  animal-sniffer is confused by the signature of CharBuffer.subSequence()
-     *  due to declaration of this method has been changed since Java7.
-     *  (abstract -> non-abstract)
-     *
-     * @param cb a buffer
-     * @param start start of sub sequence
-     * @param end end of sub sequence
-     * @return sub sequence.
-     */
-    @IgnoreJRERequirement
-    private CharSequence getSubSequence(CharBuffer cb, int start, int end) {
-        return cb.subSequence(start, end);
-    }
-
-    /**
      * Main loop for connecting and reading Gerrit JSON Events and dispatching them to Workers.
      */
     @Override
@@ -395,7 +351,7 @@ public class GerritConnection extends Thread implements Connector {
                 }
                 Reader reader = new InputStreamReader(channel.getInputStream(), "utf-8");
                 channel.connect();
-                CharBuffer cb = CharBuffer.allocate(sshRxBufferSize);
+                LineQueue lq = new LineQueue();
                 notifyConnectionEstablished();
                 Provider provider = new Provider(
                         gerritName,
@@ -407,10 +363,11 @@ public class GerritConnection extends Thread implements Connector {
                 logger.info("Ready to receive data from Gerrit: " + gerritName);
                 String line;
                 Integer readCount;
-                while ((readCount = reader.read(cb)) != -1) {
+                while ((readCount = reader.read(lq.getBuffer())) != -1) {
                     logger.debug("Read count from Gerrit stream: {}", String.valueOf(readCount));
-                    while ((line = getLine(cb)) != null) {
-                        logger.debug("Data-line from Gerrit: {}", line);
+                    lq.commit();
+                    while ((line = lq.poll()) != null) {
+                        logger.info("Data-line from Gerrit: {}", line);
                         if (handler != null) {
                             handler.post(line, provider);
                         }

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/util/LineQueue.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/util/LineQueue.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 public class LineQueue {
 
     private static final int DEFAULT_BUFFER_SIZE = 16384;
-    private static final char LINE_SEPARATOR = "\n".charAt(0);
+    private static final char LINE_SEPARATOR = '\n';
 
 
     private static final Logger logger = LoggerFactory.getLogger(LineQueue.class);

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/util/LineQueue.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/util/LineQueue.java
@@ -1,0 +1,200 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2017 rinrinne All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.tools.gerrit.gerritevents.util;
+
+import java.nio.CharBuffer;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A queue for line in text.
+ *
+ * @author rinrinne (rinrin.ne@gmail.com)
+ *
+ */
+public class LineQueue {
+
+    private static final int DEFAULT_BUFFER_SIZE = 16384;
+    private static final char LINE_SEPARATOR = "\n".charAt(0);
+
+
+    private static final Logger logger = LoggerFactory.getLogger(LineQueue.class);
+
+    /**
+     * Line Queue.
+     */
+    protected final Queue<String> lineQueue;
+    /**
+     * Charactor Buffer to get data from reader.
+     */
+    protected final CharBuffer charBuffer;
+    /**
+     * List for remaining data.
+     */
+    protected final List<String> remainingList;
+
+    /**
+     * Default constructor.
+     */
+    public LineQueue() {
+        this(DEFAULT_BUFFER_SIZE);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param bufSize the size of CharBuffer
+     */
+    public LineQueue(int bufSize) {
+        lineQueue = new LinkedList<String>();
+        charBuffer = CharBuffer.allocate(bufSize);
+        remainingList = new LinkedList<String>();
+    }
+
+    /**
+     * Gets buffer.
+     *
+     * @return the buffer
+     */
+    public CharBuffer getBuffer() {
+        if (!charBuffer.hasRemaining()) {
+            charBuffer.clear();
+        }
+        return charBuffer;
+    }
+
+    /**
+     * Commits buffer to line queue.
+     *
+     * Commited buffer is no longer readable.
+     *
+     * @return the committed line count
+     */
+    public int commit() {
+        int cnt = 0;
+        String line;
+        charBuffer.flip();
+        while ((line = getLine()) != null) {
+            lineQueue.offer(line);
+            cnt++;
+        }
+        if (charBuffer.hasRemaining()) {
+            remainingList.add(charBuffer.toString());
+            charBuffer.position(charBuffer.limit());
+        }
+        return cnt;
+    }
+
+    /**
+     * Polls line from queue.
+     *
+     * Polled line is removed from queue.
+     *
+     * @return the line string in the top of queue
+     */
+    public String poll() {
+        return lineQueue.poll();
+    }
+
+    /**
+     * Checks queue is empty.
+     *
+     * @return true if queue is empty.
+     */
+    public boolean isEmpty() {
+        return lineQueue.isEmpty();
+    }
+
+    /**
+     * Checks that has remaining.
+     *
+     * @return true if has remaining.
+     */
+    public boolean hasRemainings() {
+        return !remainingList.isEmpty();
+    }
+
+    /**
+     * Gets the list of remainings.
+     *
+     * Remainings are not removed.
+     *
+     * @return the list of remainings
+     */
+    public List<String> getRemainings() {
+       return Collections.unmodifiableList(remainingList);
+    }
+
+    /**
+     * Gets a line string.
+     *
+     * @return the line string
+     */
+    protected String getLine() {
+        String line = null;
+        for (int i = 0; i < charBuffer.length(); i++) {
+            if (charBuffer.charAt(i) == LINE_SEPARATOR) {
+                line = getSubSequence(charBuffer, 0, i).toString().trim();
+                charBuffer.position(charBuffer.position() + i);
+                charBuffer.get();
+                break;
+            }
+        }
+        if (line != null) {
+            if (!remainingList.isEmpty()) {
+                StringBuilder sb = new StringBuilder();
+                for (String data : remainingList) {
+                    sb.append(data);
+                }
+                line = sb.append(line).toString();
+                remainingList.clear();
+            }
+        }
+        return line;
+    }
+
+    /**
+     *  Get sub sequence of buffer.
+     *
+     *  This method avoids error in java-api-check.
+     *  animal-sniffer is confused by the signature of CharBuffer.subSequence()
+     *  due to declaration of this method has been changed since Java7.
+     *  (abstract -> non-abstract)
+     *
+     * @param cb a buffer
+     * @param start start of sub sequence
+     * @param end end of sub sequence
+     * @return sub sequence.
+     */
+    @IgnoreJRERequirement
+    private CharSequence getSubSequence(CharBuffer cb, int start, int end) {
+        return cb.subSequence(start, end);
+    }
+}

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/util/LineQueueTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/util/LineQueueTest.java
@@ -1,0 +1,189 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2017 rinrinne All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.tools.gerrit.gerritevents.util;
+
+// CS IGNORE AvoidStarImport FOR NEXT 2 LINES. REASON: Test code
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.CharBuffer;
+
+/**
+ * A test class for LineQueue.
+ *
+ * @author rinrinne (rinrin.ne@gmail.com)
+ *
+ */
+public class LineQueueTest {
+
+    /**
+     * Link queue.
+     */
+    private LineQueue lq = null;
+
+    /**
+     * Setup for each test.
+     */
+    @Before
+    public void before() {
+        // CS IGNORE MagicNumber FOR NEXT 1 LINES. REASON: Test code.
+        lq = new LineQueue(21);
+    }
+
+    /**
+     * Test method for {@link com.sonymobile.tools.gerrit.gerritevents.util.LineQueue#commit()}.
+     */
+    @Test
+    public void testCommit() {
+    }
+
+    /**
+     * Test one line.
+     */
+    @Test
+    public void testOneLine() {
+        CharBuffer cb = lq.getBuffer();
+        cb.append("0123456789012345\n");
+        lq.commit();
+        assertThat(lq.poll(), is(equalTo("0123456789012345")));
+        assertThat(lq.poll(), nullValue());
+    }
+
+    /**
+     * Test one line with delimiter just before boundary.
+     */
+    @Test
+    public void testOneLineBoundary() {
+        CharBuffer cb = lq.getBuffer();
+        cb.append("01234567890123456789\n");
+        lq.commit();
+        assertThat(lq.poll(), is(equalTo("01234567890123456789")));
+        assertThat(lq.poll(), nullValue());
+    }
+
+    /**
+     * Test two lines.
+     */
+    @Test
+    public void testTwoLines() {
+        CharBuffer cb = lq.getBuffer();
+        cb.append("0123456789\n012345\n");
+        lq.commit();
+        assertThat(lq.poll(), is(equalTo("0123456789")));
+        assertThat(lq.poll(), is(equalTo("012345")));
+        assertThat(lq.poll(), nullValue());
+    }
+
+    /**
+     * Test three lines.
+     */
+    @Test
+    public void testThreeLines() {
+        CharBuffer cb = lq.getBuffer();
+        cb.append("01234\n56789\n012345\n");
+        lq.commit();
+        assertThat(lq.poll(), is(equalTo("01234")));
+        assertThat(lq.poll(), is(equalTo("56789")));
+        assertThat(lq.poll(), is(equalTo("012345")));
+        assertThat(lq.poll(), nullValue());
+    }
+
+    /**
+     * Test three lines but line 1 is empty.
+     */
+    @Test
+    public void testThreeLinesWithEmpty1() {
+        CharBuffer cb = lq.getBuffer();
+        cb.append("\n0123456789\n012345\n");
+        lq.commit();
+        assertThat(lq.poll(), is(equalTo("")));
+        assertThat(lq.poll(), is(equalTo("0123456789")));
+        assertThat(lq.poll(), is(equalTo("012345")));
+        assertThat(lq.poll(), nullValue());
+    }
+
+    /**
+     * Test three lines but line 2 is empty.
+     */
+    @Test
+    public void testThreeLinesWithEmpty2() {
+        CharBuffer cb = lq.getBuffer();
+        cb.append("0123456789\n\n012345\n");
+        lq.commit();
+        assertThat(lq.poll(), is(equalTo("0123456789")));
+        assertThat(lq.poll(), is(equalTo("")));
+        assertThat(lq.poll(), is(equalTo("012345")));
+        assertThat(lq.poll(), nullValue());
+    }
+
+    /**
+     * Test three lines but line 3 is empty.
+     */
+    @Test
+    public void testThreeLinesWithEmpty3() {
+        CharBuffer cb = lq.getBuffer();
+        cb.append("0123456789\n012345\n\n");
+        lq.commit();
+        assertThat(lq.poll(), is(equalTo("0123456789")));
+        assertThat(lq.poll(), is(equalTo("012345")));
+        assertThat(lq.poll(), is(equalTo("")));
+        assertThat(lq.poll(), nullValue());
+    }
+
+    /**
+     * Test one line but no delimiter.
+     */
+    @Test
+    public void testOneOverCapacityLine() {
+        CharBuffer cb = lq.getBuffer();
+        cb.append("01234567890123456789");
+        lq.commit();
+        assertThat(lq.poll(), nullValue());
+    }
+
+    /**
+     * Test one long line.
+     */
+    @Test
+    public void testOneLongLine() {
+        CharBuffer cb = lq.getBuffer();
+        cb.append("01234567890123456789");
+        lq.commit();
+        assertThat(lq.poll(), nullValue());
+
+        cb = lq.getBuffer();
+        cb.append("abcdefghijklmnopqrst");
+        lq.commit();
+        assertThat(lq.poll(), nullValue());
+
+        cb = lq.getBuffer();
+        cb.append("012345\n0123456789");
+        lq.commit();
+        assertThat(lq.poll(), is(equalTo("01234567890123456789abcdefghijklmnopqrst012345")));
+        assertThat(lq.poll(), nullValue());
+    }
+}


### PR DESCRIPTION
This adds a queue that converts linear character buffer to
line oriented fragments then store them.

Also add dedicated test cases in order to cover various
cases easily.

Fix: JENKINS-44568
Fix: JENKINS-44414

I started to create this PR just before creating PR #67. May be this is unnecessary if PR #67 and #68 are merged.