### PR TITLE
Add "private" and "wip" states to Change

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventKeys.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventKeys.java
@@ -74,6 +74,10 @@ public abstract class GerritEventKeys {
      */
     public static final String OWNER = "owner";
     /**
+     * private.
+     */
+    public static final String PRIVATE = "private";
+    /**
      * project.
      */
     public static final String PROJECT = "project";
@@ -89,6 +93,10 @@ public abstract class GerritEventKeys {
      * subject.
      */
     public static final String SUBJECT = "subject";
+    /**
+     * wip.
+     */
+    public static final String WIP = "wip";
     /**
      * commit message.
      */

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventType.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventType.java
@@ -38,6 +38,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ProjectCreated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetNotified;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PrivateStateChanged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.WipStateChanged;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -108,7 +109,12 @@ public enum GerritEventType {
     /***
      * A private state changed event.
      */
-    PRIVATE_STATE_CHANGED("private-state-changed",true, PrivateStateChanged.class);
+    PRIVATE_STATE_CHANGED("private-state-changed",true, PrivateStateChanged.class),
+
+    /***
+     * A work in progress state chaned event.
+     */
+    WIP_STATE_CHANGED("wip-state-changed", true, WipStateChanged.class);
 
     private String typeValue;
     private boolean interesting;

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventType.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventType.java
@@ -37,6 +37,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.ReviewerAdded;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ProjectCreated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetNotified;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PrivateStateChanged;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -102,7 +103,12 @@ public enum GerritEventType {
     /***
      * A merge-failed event.
      */
-    MERGE_FAILED("merge-failed", true, MergeFailed.class);
+    MERGE_FAILED("merge-failed", true, MergeFailed.class),
+
+    /***
+     * A private state changed event.
+     */
+    PRIVATE_STATE_CHANGED("private-state-changed",true, PrivateStateChanged.class);
 
     private String typeValue;
     private boolean interesting;

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/attr/Change.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/attr/Change.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory.getBoolean;
 import static com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory.getString;
 import static com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory.getDate;
 
@@ -47,7 +48,8 @@ import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.SUBJE
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.URL;
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.CREATED_ON;
 import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.LAST_UPDATED;
-
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.WIP;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.PRIVATE;
 
 /**
  * Represents a Gerrit JSON Change DTO.
@@ -104,6 +106,17 @@ public class Change implements GerritJsonDTO {
     private Date lastUpdated;
 
     private List<Comment> comments;
+
+    /**
+     * Is this change a Work in progress.
+     */
+    private boolean wip;
+
+    /**
+     * Is this change private.
+     */
+    private boolean isPrivate;
+
     /**
      * Default constructor.
      */
@@ -143,6 +156,8 @@ public class Change implements GerritJsonDTO {
             commitMessage = getString(json, COMMIT_MESSAGE);
         }
         url = getString(json, URL);
+        wip = getBoolean(json, WIP, false);
+        isPrivate = getBoolean(json, PRIVATE, false);
     }
 
     /**
@@ -330,6 +345,30 @@ public class Change implements GerritJsonDTO {
     public void setLastUpdated(Date date) {
         this.lastUpdated = date;
     }
+
+    /**
+     * Is this change a work in progress.
+     * @return change is in WIP state.
+     */
+    public boolean isWip() { return wip; }
+
+    /**
+     * Is this change a work in progress.
+     * @param boolean change is in WIP state.
+     */
+    public void setWip(boolean wip) { this.wip = wip; }
+
+    /**
+     * Is this change private.
+     * @return change is in private state.
+     */
+    public boolean isPrivate() { return isPrivate; }
+
+    /**
+     * Is this change private.
+     * @param boolean change is private.
+     */
+    public void setPrivate(boolean isPrivate) {this.isPrivate = isPrivate; }
 
     @Override
     public boolean equals(Object obj) {

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/PrivateStateChanged.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/PrivateStateChanged.java
@@ -1,0 +1,48 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2017 Axis Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.tools.gerrit.gerritevents.dto.events;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventType;
+
+/**
+ * A DTO representation of the private-state-changed Gerrit Event.
+ *
+ * @author Sven Selberg &lt;sven.selberg@axis.com&gt;
+ */
+public class PrivateStateChanged extends ChangeBasedEvent {
+  @Override
+  public GerritEventType getEventType() {
+    return GerritEventType.PRIVATE_STATE_CHANGED;
+  }
+
+  @Override
+  public boolean isScorable() {
+    return !change.isPrivate();
+  }
+
+  @Override
+  public String toString() {
+    return "PrivateStateChanged: " + change;
+  }
+}

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/WipStateChanged.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/WipStateChanged.java
@@ -1,0 +1,44 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2017 Axis Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.tools.gerrit.gerritevents.dto.events;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventType;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
+
+/**
+ * A DTO representation of the wip-state-changed Gerrit Event.
+ *
+ * @author Sven Selberg &lt;sven.selberg@axis.com&gt;
+ */
+public class WipStateChanged extends ChangeBasedEvent {
+  @Override
+  public GerritEventType getEventType() {
+    return GerritEventType.PRIVATE_STATE_CHANGED;
+  }
+
+  @Override
+  public boolean isScorable() {
+    return !change.isWip();
+  }
+}

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritHandlerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritHandlerTest.java
@@ -37,6 +37,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefUpdated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ReviewerAdded;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ProjectCreated;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PrivateStateChanged;
 
 import org.junit.After;
 import org.junit.Before;
@@ -384,6 +385,10 @@ public class GerritHandlerTest {
         MergeFailed mergeFailed = new MergeFailed();
         handler.notifyListeners(mergeFailed);
         verify(listenerMock, times(1)).gerritEvent(mergeFailed);
+
+        PrivateStateChanged privateStateChanged = new PrivateStateChanged();
+        handler.notifyListeners(privateStateChanged);
+        verify(listenerMock, times(1).gerritEvent(privateStateChanged));
     }
 
     /**
@@ -563,6 +568,22 @@ public class GerritHandlerTest {
     }
 
     /**
+     * Tests that PrivateStateChanged events are going in the method with
+     * that type as parameter and that other type of events are going
+     * in the default method.
+     */
+    @Test
+    public void testEventNotificationWithListenerPrivateStateChangedMethodSignature() {
+        SpecificEventListener stateChangedListener = new SpecificEventListener() {
+            @SuppressWarnings("unused") //method is called by reflection
+            public void gerritEvent(PrivateStateChanged event) {
+                specificMethodCalled = true;
+            }
+        };
+        testListenerWithSpecificSignature(stateChangedListener, new PrivateStateChanged());
+    }
+
+    /**
      * Base test listener implementation.
      */
     private abstract static class SpecificEventListener implements GerritEventListener {
@@ -596,7 +617,8 @@ public class GerritHandlerTest {
                                                      new DraftPublished(),
                                                      new PatchsetCreated(),
                                                      new RefUpdated(),
-                                                     new ProjectCreated(), };
+                                                     new ProjectCreated(),
+                                                     new PrivateStateChanged(),};
         handler.addListener(listener);
 
         // Validate that event was sent to the specific method

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritHandlerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritHandlerTest.java
@@ -38,6 +38,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.ReviewerAdded;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ProjectCreated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PrivateStateChanged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.WipStateChanged;
 
 import org.junit.After;
 import org.junit.Before;
@@ -389,6 +390,10 @@ public class GerritHandlerTest {
         PrivateStateChanged privateStateChanged = new PrivateStateChanged();
         handler.notifyListeners(privateStateChanged);
         verify(listenerMock, times(1).gerritEvent(privateStateChanged));
+
+        WipStateChanged wipStateChanged = new WipStateChanged();
+        handler.notifyListeners(wipStateChanged);
+        verify(listenerMock, times(1).gerritEvent(wipStateChanged));
     }
 
     /**
@@ -584,6 +589,22 @@ public class GerritHandlerTest {
     }
 
     /**
+     * Tests that WipStateChanged events are going in the method with
+     * that type as parameter and that other type of events are going
+     * in the default method.
+     */
+    @Test
+    public void testEventNotificationWithListenerWipStateChangedMethodSignature() {
+        SpecificEventListener stateChangedListener = new SpecificEventListener() {
+            @SuppressWarnings("unused") //method is called by reflection
+            public void gerritEvent(WipStateChanged event) {
+                specificMethodCalled = true;
+            }
+        };
+        testListenerWithSpecificSignature(stateChangedListener, new WipStateChanged());
+    }
+
+    /**
      * Base test listener implementation.
      */
     private abstract static class SpecificEventListener implements GerritEventListener {
@@ -618,7 +639,8 @@ public class GerritHandlerTest {
                                                      new PatchsetCreated(),
                                                      new RefUpdated(),
                                                      new ProjectCreated(),
-                                                     new PrivateStateChanged(),};
+                                                     new PrivateStateChanged(),
+                                                     new WipStateChanged(), };
         handler.addListener(listener);
 
         // Validate that event was sent to the specific method

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/dto/attr/ChangeTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/dto/attr/ChangeTest.java
@@ -241,6 +241,8 @@ public class ChangeTest {
         change2.setSubject("subject");
         change2.setOwner(account);
         change2.setUrl("http://localhost:8080");
+        change2.setWip(false);
+        change2.setPrivate(false);
 
         assertTrue(change.equals(change2));
     }


### PR DESCRIPTION
Gerrit version 2.15 adds two new attributes to the change, "wip" and
"private" that replaces the old "draft" state [1].

[1] https://gerrit-review.googlesource.com/c/gerrit/+/148751