### PR TITLE
Print the listener and event class in case of InvocationTargetException

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritHandler.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritHandler.java
@@ -322,6 +322,7 @@ public class GerritHandler implements Coordinator, Handler {
                + "Calling default.", ex);
             listener.gerritEvent(event);
         } catch (InvocationTargetException ex) {
+            logger.error("When notifying listener: {} about event: {}", listener, event);
             logger.error("Exception thrown during event handling.", ex);
         } catch (NoSuchMethodException ex) {
             logger.debug("No apropriate method found during reflection. Calling default.", ex);


### PR DESCRIPTION
Extend logging in case of exception in third-party gerrit listeners. In current implementation if `NullPointerException` occurs user can see only: `Exception thrown during event handling: null` in the logs.