### PR TITLE
Prevent receiving list of random changes for empty topic name

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/attr/Change.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/attr/Change.java
@@ -31,6 +31,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.rest.Topic;
 import com.sonymobile.tools.gerrit.gerritevents.helpers.FileHelper;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -131,10 +132,15 @@ public class Change implements GerritJsonDTO {
      */
     @SuppressWarnings("unused")
     private Object readResolve() {
-        if (topic != null) {
+        if (StringUtils.isNotEmpty(topic)) {
             topicObject = new Topic(topic);
             topic = null;
         }
+
+        if (topicObject != null && StringUtils.isEmpty(topicObject.getName())) {
+            topicObject = null;
+        }
+
         return this;
     }
 
@@ -176,7 +182,10 @@ public class Change implements GerritJsonDTO {
             commitMessage = getString(json, COMMIT_MESSAGE);
         }
         if (json.containsKey(TOPIC)) {
-            topicObject = new Topic(getString(json, TOPIC));
+            String topicName = getString(json, TOPIC);
+            if (StringUtils.isNotEmpty(topicName)) {
+                topicObject = new Topic(topicName);
+            }
         }
 
         url = getString(json, URL);

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/TopicChanged.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/TopicChanged.java
@@ -32,6 +32,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Account;
 
 import com.sonymobile.tools.gerrit.gerritevents.dto.rest.Topic;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * A DTO representation of the topic-changed Gerrit Event.
@@ -61,10 +62,15 @@ public class TopicChanged  extends ChangeBasedEvent {
      */
     @SuppressWarnings("unused")
     private Object readResolve() {
-        if (oldTopic != null) {
+        if (StringUtils.isNotEmpty(oldTopic)) {
             oldTopicObject = new Topic(oldTopic);
             oldTopic = null;
         }
+
+        if (oldTopicObject != null && StringUtils.isEmpty(oldTopicObject.getName())) {
+            oldTopicObject = null;
+        }
+
         return this;
     }
 

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/rest/Topic.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/rest/Topic.java
@@ -30,10 +30,12 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.PatchSet;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +73,11 @@ public class Topic {
      * @return the map of pairs change-patchset related to this topic.
      */
     public Map<Change, PatchSet> getChanges(GerritQueryHandler gerritQueryHandler) {
+        if (StringUtils.isEmpty(name)) {
+            logger.error("Topic name can not be empty");
+            return Collections.emptyMap();
+        }
+
         if (changes == null) {
             Map<Change, PatchSet> temp = new HashMap<Change, PatchSet>();
             try {


### PR DESCRIPTION
Unfortunately, sometimes Gerrit sends empty topic field or Jenkins deserialise topic as empty string. To prevent receiving list of random changes for empty topic this change adds explicit checks.

And because we are using masked topic name (`{}`) to support spaces, commas and other things we end up in have full list of all gerrit changes (with some limit on gerrit side):
```
ssh -p PORT user@gerrit gerrit query --current-patch-set --format=JSON topic:{} | wc -l
501
```

Without mask (no entries found):
```
ssh -p PORT user@gerrit gerrit query --current-patch-set --format=JSON topic: | wc -l
1
```

So, now we forcibly switch topic/topicObject to null if name is empty and check that we don't query changes for empty topic name.