### PR TITLE
Add hashtags-changed event

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventKeys.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventKeys.java
@@ -265,6 +265,10 @@ public abstract class GerritEventKeys {
      * reason.
      */
     public static final String REASON = "reason";
+    /**
+     * hashtags.
+     */
+    public static final String HASHTAGS = "hashtags";
 
     /**
      * Empty default constructor to hinder instantiation.

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventType.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritEventType.java
@@ -39,6 +39,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.ProjectCreated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetNotified;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PrivateStateChanged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.WipStateChanged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.HashtagsChanged;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -114,7 +115,12 @@ public enum GerritEventType {
     /***
      * A work in progress state changed event.
      */
-    WIP_STATE_CHANGED("wip-state-changed", true, WipStateChanged.class);
+    WIP_STATE_CHANGED("wip-state-changed", true, WipStateChanged.class),
+
+    /**
+     * A hashtags changed event.
+     */
+    HASHTAGS_CHANGED("hashtags-changed", true, HashtagsChanged.class);
 
     private String typeValue;
     private boolean interesting;

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/HashtagsChanged.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/HashtagsChanged.java
@@ -1,0 +1,74 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2018 Diogo Ferreira <diogo@underdev.org> All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+package com.sonymobile.tools.gerrit.gerritevents.dto.events;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventType;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.HASHTAGS;
+
+/**
+ * A DTO representation of the hashtags-changed Gerrit Event.
+ * @author Diogo Ferreira &lt;diogo@underdev.org&gt;
+ */
+public class HashtagsChanged extends ChangeBasedEvent {
+    private List<String> hashtags;
+
+    @Override
+    public GerritEventType getEventType() {
+        return GerritEventType.HASHTAGS_CHANGED;
+    }
+
+    @Override
+    public boolean isScorable() {
+        return false;
+    }
+
+    /**
+     * Obtains the list of hashtags.
+     * @return A list of strings, each containing a hashtag.
+     */
+    public List<String> getHashtags() {
+        return hashtags;
+    }
+
+    @Override
+    public void fromJson(JSONObject json) {
+        super.fromJson(json);
+
+        if (json.containsKey(HASHTAGS)) {
+            JSONArray hashtagsArray = json.getJSONArray("hashtags");
+            List<String> result = new ArrayList<String>(hashtagsArray.size());
+            for (Object tag : hashtagsArray) {
+                result.add(tag.toString());
+            }
+            this.hashtags = result;
+        }
+    }
+}

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritHandlerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritHandlerTest.java
@@ -39,6 +39,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ProjectCreated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PrivateStateChanged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.WipStateChanged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.HashtagsChanged;
 
 import org.junit.After;
 import org.junit.Before;
@@ -438,6 +439,10 @@ public class GerritHandlerTest {
         WipStateChanged wipStateChanged = new WipStateChanged();
         handler.notifyListeners(wipStateChanged);
         verify(listenerMock, times(1)).gerritEvent(wipStateChanged);
+
+        HashtagsChanged hashtagsChanged = new HashtagsChanged();
+        handler.notifyListeners(hashtagsChanged);
+        verify(listenerMock, times(1)).gerritEvent(hashtagsChanged);
     }
 
     /**
@@ -646,6 +651,22 @@ public class GerritHandlerTest {
             }
         };
         testListenerWithSpecificSignature(stateChangedListener, new WipStateChanged());
+    }
+
+    /**
+     * Tests that HashtagsChanged events are going in the method with
+     * that type as parameter and that other type of events are going
+     * in the default method.
+     */
+    @Test
+    public void testEventNotificationWithListenerHashtagsChangedMethodSignature() {
+        SpecificEventListener stateChangedListener = new SpecificEventListener() {
+            @SuppressWarnings("unused") //method is called by reflection
+            public void gerritEvent(HashtagsChanged event) {
+                specificMethodCalled = true;
+            }
+        };
+        testListenerWithSpecificSignature(stateChangedListener, new HashtagsChanged());
     }
 
     /**

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/HashtagsChangedTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/HashtagsChangedTest.java
@@ -1,0 +1,59 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2018 Diogo Ferreira
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+package com.sonymobile.tools.gerrit.gerritevents.dto.events;
+
+import com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory;
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Diogo Ferreira (diogo@underdev.org)
+ */
+public class HashtagsChangedTest {
+
+    /**
+     * Given an hashtag changed event in JSON format, it can be converted correctly.
+     * @throws IOException if the json file cannot be loaded.
+     */
+    @Test
+    public void fromJsonShouldDeserializeHashtagsCorrectly() throws IOException {
+        InputStream stream = getClass().getResourceAsStream("DeserializeHashtagsChangedTest.json");
+        String json = IOUtils.toString(stream);
+        JSONObject jsonObject = JSONObject.fromObject(json);
+        GerritEvent evt = GerritJsonEventFactory.getEvent(jsonObject);
+
+        assertTrue("is an HashtagsChanged", evt instanceof HashtagsChanged);
+        assertEquals("Hashtags match", Arrays.asList("works", "yolo"), ((HashtagsChanged)evt).getHashtags());
+    }
+}

--- a/src/test/resources/com/sonymobile/tools/gerrit/gerritevents/dto/events/DeserializeHashtagsChangedTest.json
+++ b/src/test/resources/com/sonymobile/tools/gerrit/gerritevents/dto/events/DeserializeHashtagsChangedTest.json
@@ -1,0 +1,37 @@
+{
+  "editor": {
+    "name": "Diogo",
+    "email": "diogo@example.org",
+    "username": "defer"
+  },
+  "removed": [
+    "tag"
+  ],
+  "hashtags": [
+    "works",
+    "yolo"
+  ],
+  "change": {
+    "project": "platform/build",
+    "branch": "master",
+    "id": "Icd27d85f4c4bc6e95abe8a514a32a68e6f97f181",
+    "number": 1000,
+    "subject": "Implement things",
+    "owner": {
+      "name": "Diogo",
+      "email": "diogo@example.org",
+      "username": "defer"
+    },
+    "url": "http://gerrit.local/1000",
+    "commitMessage": "Implement things\n\nChange-Id: Icd27d85f4c4bc6e95abe8a514a32a68e6f97f181\n",
+    "createdOn": 1539093819,
+    "status": "NEW"
+  },
+  "project": "platform/build",
+  "refName": "refs/heads/master",
+  "changeKey": {
+    "id": "Icd27d85f4c4bc6e95abe8a514a32a68e6f97f181"
+  },
+  "type": "hashtags-changed",
+  "eventCreatedOn": 1539112429
+}


### PR DESCRIPTION
With the arrival of NoteDB[1], gerrit now supports hashtags on changes
which might open interesting use-cases, like go's use of hashtags for
managing CL[2].

This patch adds support for the hashtag changed event.

[1] https://gerrit-review.googlesource.com/Documentation/note-db.html
[2] https://github.com/golang/go/issues/24836