### PR TITLE
Cache the existing SSH connection for GerritQueryHandler

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandler.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandler.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
  */
 public class GerritQueryHandler {
 
-    static final Logger logger = LoggerFactory.getLogger(GerritQueryHandler.class);
+    protected static final Logger logger = LoggerFactory.getLogger(GerritQueryHandler.class);
     /**
      * The base of the query ssh command to send to Gerrit.
      */

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandler.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandler.java
@@ -43,6 +43,10 @@ import org.slf4j.LoggerFactory;
  */
 public class GerritQueryHandler {
 
+    /**
+     * Logger instance.
+     * Set protected to allow it  to be used in subclasses.
+     */
     protected static final Logger logger = LoggerFactory.getLogger(GerritQueryHandler.class);
     /**
      * The base of the query ssh command to send to Gerrit.

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandler.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandler.java
@@ -48,11 +48,11 @@ public class GerritQueryHandler {
      * The base of the query ssh command to send to Gerrit.
      */
     public static final String QUERY_COMMAND = "gerrit query";
-    final String gerritHostName;
-    final int gerritSshPort;
-    final String gerritProxy;
-    final Authentication authentication;
-    final int connectionTimeout;
+    private final String gerritHostName;
+    private final int gerritSshPort;
+    private final String gerritProxy;
+    private final Authentication authentication;
+    private final int connectionTimeout;
 
 
     /**

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandler.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandler.java
@@ -43,16 +43,16 @@ import org.slf4j.LoggerFactory;
  */
 public class GerritQueryHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(GerritQueryHandler.class);
+    static final Logger logger = LoggerFactory.getLogger(GerritQueryHandler.class);
     /**
      * The base of the query ssh command to send to Gerrit.
      */
     public static final String QUERY_COMMAND = "gerrit query";
-    private final String gerritHostName;
-    private final int gerritSshPort;
-    private final String gerritProxy;
-    private final Authentication authentication;
-    private final int connectionTimeout;
+    final String gerritHostName;
+    final int gerritSshPort;
+    final String gerritProxy;
+    final Authentication authentication;
+    final int connectionTimeout;
 
 
     /**
@@ -368,8 +368,7 @@ public class GerritQueryHandler {
 
         SshConnection ssh = null;
         try {
-            ssh = SshConnectionFactory.getConnection(gerritHostName, gerritSshPort, gerritProxy,
-                                                                        authentication, connectionTimeout);
+            ssh = getConnection();
             BufferedReader reader = new BufferedReader(ssh.executeCommandReader(str.toString()));
             String incomingLine = null;
             while ((incomingLine = reader.readLine()) != null) {
@@ -379,9 +378,29 @@ public class GerritQueryHandler {
             logger.trace("Closing reader.");
             reader.close();
         } finally {
-            if (ssh != null) {
-                ssh.disconnect();
-            }
+            cleanupConnection(ssh);
+        }
+    }
+
+    /**
+     * Creates a new SSH connection used to execute the queries.
+     *
+     * @return a fresh instance of {@link SshConnection}
+     * @throws IOException for IO issues
+     */
+    protected SshConnection getConnection() throws IOException {
+        return SshConnectionFactory.getConnection(gerritHostName, gerritSshPort, gerritProxy,
+                authentication, connectionTimeout);
+    }
+
+    /**
+     * Cleans up the SSH connection.
+     *
+     * @param ssh the SSH connection
+     */
+    protected void cleanupConnection(SshConnection ssh) {
+        if (ssh != null) {
+            ssh.disconnect();
         }
     }
 

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandlerWithPersistedConnection.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandlerWithPersistedConnection.java
@@ -1,0 +1,75 @@
+package com.sonymobile.tools.gerrit.gerritevents;
+
+import com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnection;
+
+import java.io.IOException;
+
+/**
+ * {@link GerritQueryHandler} with a persisted SSH connection.
+ * Saves the performance overhead of creating a new connection for each query.
+ */
+public class GerritQueryHandlerWithPersistedConnection extends GerritQueryHandler {
+
+    private SshConnection activeConnection = null;
+
+    /**
+     * Creates a {@link GerritQueryHandler} with persisted SSH connection.
+     *
+     * @param gerritHostName    the hostName
+     * @param gerritSshPort     the ssh port that the gerrit server listens to.
+     * @param gerritProxy       the ssh Proxy url
+     * @param authentication    the authentication credentials.
+     * @param connectionTimeout the connection timeout.
+     */
+    public GerritQueryHandlerWithPersistedConnection(String gerritHostName, int gerritSshPort,
+                                                     String gerritProxy, Authentication authentication,
+                                                     int connectionTimeout) {
+        super(gerritHostName, gerritSshPort, gerritProxy, authentication, connectionTimeout);
+    }
+
+    /**
+     * Returns a fresh SSH connection if the persisted one is not valid.
+     * Otherwise returns the existing connection.
+     *
+     * @return an active SSH connection
+     * @throws IOException for IO issues
+     */
+    @Override
+    protected SshConnection getConnection() throws IOException {
+        if (!isPersistedConnectionValid()) {
+            activeConnection = super.getConnection();
+            logger.trace("SSH connection is not valid anymore, a new one was created.");
+        }
+        return activeConnection;
+    }
+
+    /**
+     * Do not cleanup the current connection since we want to persist it.
+     *
+     * @param ssh the current SSH connection
+     */
+    @Override
+    protected void cleanupConnection(SshConnection ssh) {
+        // do nothing
+    }
+
+    /**
+     * Checks if the persisted connection is still valid.
+     *
+     * @return true if the persistent connection is valid.
+     */
+    private boolean isPersistedConnectionValid() {
+        return activeConnection != null && activeConnection.isConnected();
+    }
+
+    /**
+     * Disconnects the persisted connection.
+     */
+    public void disconnect() {
+        if (isPersistedConnectionValid()) {
+            activeConnection.disconnect();
+            logger.trace("The persisted SSH connection was disconnected.");
+        }
+    }
+}

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandlerTestBase.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandlerTestBase.java
@@ -1,0 +1,58 @@
+package com.sonymobile.tools.gerrit.gerritevents;
+
+import com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnection;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnectionFactory;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.Reader;
+import java.io.StringReader;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test base for testing {@link com.sonymobile.tools.gerrit.gerritevents.GerritQueryHandler} implementations.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(SshConnectionFactory.class)
+@PowerMockIgnore("org.slf4j.*") // Prevent warning about multiple sl4fj binding
+public abstract class GerritQueryHandlerTestBase {
+
+    GerritQueryHandler queryHandler;
+
+    SshConnection sshConnectionMock;
+
+    /**
+     * Prepare mock for sshConnection.
+     *
+     * @throws Exception when something wrong.
+     */
+    @Before
+    public void setUp() throws Exception {
+
+        sshConnectionMock = mock(SshConnection.class);
+
+        PowerMockito.mockStatic(SshConnectionFactory.class);
+        PowerMockito.doReturn(sshConnectionMock).when(SshConnectionFactory.class, "getConnection",
+                isA(String.class), isA(Integer.class), isA(String.class), isA(Authentication.class), isA(Integer.class));
+
+        when(sshConnectionMock.isConnected()).thenReturn(true);
+        when(sshConnectionMock.executeCommandReader(anyString())).thenAnswer(new Answer<Reader>() {
+
+            @Override
+            public Reader answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return new StringReader("{\"project\":\"test\"}");
+            }
+        });
+    }
+}

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandlerWithPersistedConnectionTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritQueryHandlerWithPersistedConnectionTest.java
@@ -1,0 +1,41 @@
+package com.sonymobile.tools.gerrit.gerritevents;
+
+import com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.SshConnectionFactory;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
+/**
+ * Tests for {@link com.sonymobile.tools.gerrit.gerritevents.GerritQueryHandlerWithPersistedConnection}.
+ *
+ * @author : apetres
+ */
+public class GerritQueryHandlerWithPersistedConnectionTest extends GerritQueryHandlerTestBase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        queryHandler = new GerritQueryHandlerWithPersistedConnection("", 0, "", new Authentication(null, ""), 0);
+    }
+
+    /**
+     * Test {@Link GerritQueryHandlerWithPersistedConnection.queryJava} creates only a single SSH connection
+     * regardless of the number of times it is called.
+     *
+     * @throws Exception when something wrong.
+     */
+    @Test
+    public void sshConnectionIsCreatedOnlyOnce() throws Exception {
+
+        queryHandler.queryJava("X");
+        queryHandler.queryJava("Y");
+
+        verifyStatic(SshConnectionFactory.class, times(1));
+        SshConnectionFactory.getConnection(anyString(), anyInt(), anyString(), any(Authentication.class), anyInt());
+    }
+}


### PR DESCRIPTION
Recreating the SSH connection for each query may be slow.
Let's support keeping one open all the time.
My queries are 4 times faster now :D

Plan to use it from [jira-gerrit-plugin](https://github.com/MeetMe/jira-gerrit-plugin).
