### PR TITLE
Also use comment equality in CommentAdded events

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/CommentAdded.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/events/CommentAdded.java
@@ -105,4 +105,22 @@ public class CommentAdded extends ChangeBasedEvent {
             }
         }
     }
+
+    @Override
+    public int hashCode() {
+        return 31 * super.hashCode() + (comment != null ? comment.hashCode() : 0);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        CommentAdded event = (CommentAdded)o;
+        if (comment == null) {
+            return event.comment == null;
+        }
+        return comment.equals(event.comment);
+    }
 }


### PR DESCRIPTION
When comparing two CommentAdded events to see if they're equal, we
should not only take the change and the patchset into account, but also
the comment that triggered the event. Override the hashCode and equals
methods in CommentAdded to check the comment in addition to the fields
already used by ChangeBasedEvent (its superclass).

Fixes #90 