### PR TITLE
Update SshdServerMock.java

### DIFF
--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/mock/SshdServerMock.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/mock/SshdServerMock.java
@@ -257,7 +257,7 @@ public class SshdServerMock implements CommandFactory {
     public static SshServer startServer(int port, SshdServerMock server) throws IOException {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(port);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider("hostkey.ser"));
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider("hostkey.ser", "RSA"));
         sshd.setPublickeyAuthenticator(new PublickeyAuthenticator() {
             @Override
             public boolean authenticate(String s, PublicKey publicKey, ServerSession serverSession) {


### PR DESCRIPTION
Fix test error: https://github.com/sonyxperiadev/gerrit-events/runs/2057458745
java.security.InvalidKeyException: The security strength of SHA-1 digest algorithm is not sufficient for this key size