### PR TITLE
Bump JSch from 0.1.55 to 0.1.58

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,9 @@
             <version>0.3.0</version>
         </dependency>-->
         <dependency>
-            <groupId>com.jcraft</groupId>
+            <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.55</version>
+            <version>0.1.58</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
As described in https://github.com/mwiede/jsch, the official repo is not maintained anymore, so let's switch to the fork provided by @mwiede This is supposed to fix #113.