### PR TITLE
Added a new change kind, NO_CHANGE

### DIFF
--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritChangeKind.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/dto/GerritChangeKind.java
@@ -43,6 +43,11 @@ public enum GerritChangeKind {
      */
     NO_CODE_CHANGE("NO_CODE_CHANGE"),
     /**
+     * No changes (same parent tree, same code delta, same commit message,
+     * only the patch set SHA-1 is different).
+     */
+    NO_CHANGE("NO_CHANGE"),
+    /**
      * Catch-all type if Gerrit adds a new ChangeKind we don't know about.
      */
     UNKNOWN("UNKNOWN");


### PR DESCRIPTION
Since 2015, NO_CHANGE is a possible kind for a change. This means that only the SHA-1 differs, so even more trivial than a trivial rebase or no code change.
This should be checked by the gerrit-trigger if either exclude trivial rebase or exclude no code change is selected, thus it needs to be added here.