### PR TITLE
Feat/prepare support https events

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,109 @@ Most of the development will still target the Jenkins plugin, but now it can als
   - robert.sandell@cloudbees.com
   - sandell.robert@gmail.com
 
+## Transport Options
+
+The library supports multiple transport mechanisms for receiving Gerrit events.
+
+### SSH Stream-Events (Default)
+
+The traditional transport. The library opens a persistent SSH connection to the Gerrit server and runs `gerrit stream-events`. Events arrive in near real-time.
+
+```java
+connection = new GerritConnection(name, config);
+GerritHandler handler = new GerritHandler();
+connection.setHandler(handler);
+connection.addListener(gerritConnectionListener);
+connection.start();
+```
+
+### HTTPS Polling (New in 2.22)
+
+The library can poll the Gerrit REST API over HTTPS to detect changes. No SSH connection is required. Use `GerritRestPoller` instead of `GerritConnection` — both implement the `GerritEventSource` interface.
+
+```java
+GerritEventSource source;
+if (config.isUseHttpsPoller()) {
+    source = new GerritRestPoller(name, config);
+} else {
+    source = new GerritConnection(name, config);
+}
+source.setHandler(handler);
+source.addListener(gerritConnectionListener);
+source.start();
+```
+
+**How polling works:**
+- Polls `GET /a/changes/?q=is:open` periodically (configurable interval)
+- Tracks known changes by `(changeId → revision, status, topic, wip, isPrivate)`
+- Detects changes and constructs event DTOs, then posts to `GerritHandler`
+
+**Events detected via HTTPS polling:**
+
+| Event | Detection method |
+|-------|-----------------|
+| `PatchsetCreated` | New change or revision change |
+| `ChangeMerged` | Status transition to MERGED |
+| `ChangeAbandoned` | Status transition to ABANDONED |
+| `TopicChanged` | Topic field change on known change |
+| `WipStateChanged` | `work_in_progress` field toggle |
+| `PrivateStateChanged` | `is_private` field toggle |
+
+**Limitations:** The following events cannot be detected via REST API polling because the Gerrit REST API does not expose the necessary data: `CommentAdded`, `DraftPublished`, `RefUpdated`, `ProjectCreated`, `ChangeDeleted`, `MergeFailed`, `ReviewerAdded`, `VoteDeleted`, `RefReplicated`, `RefReplicationDone`, `PatchsetNotified`, `HashtagsChanged`.
+
+### REST API Queries (New in 2.22)
+
+`GerritRestQueryHandler` extends `GerritQueryHandler` and executes queries via the Gerrit REST API (`GET /a/changes/`) instead of SSH `gerrit query`. Existing callers like `FileHelper` and `Topic` work unchanged because REST API responses are converted to the same JSON format.
+
+```java
+GerritQueryHandler handler;
+if (config.isUseHttpsPoller()) {
+    handler = new GerritRestQueryHandler(config);
+} else {
+    handler = new GerritQueryHandler(config);
+}
+List<JSONObject> results = handler.queryJava("status:open");
+```
+
+## Architecture
+
+The library uses a common `GerritEventSource` interface for all transport implementations:
+
+```
+GerritEventSource (interface)
+  ├─ GerritConnection (SSH stream-events)
+  └─ GerritRestPoller (HTTPS polling)
+
+GerritQueryHandler (base)
+  ├─ GerritQueryHandler (SSH gerrit query)
+  └─ GerritRestQueryHandler (REST API query)
+```
+
+Both `GerritConnection` and `GerritRestPoller` feed events to `GerritHandler`, which routes them to registered `GerritEventListener` implementations.
+
+## Configuration
+
+The `GerritConnectionConfig2` interface provides the configuration needed for both SSH and HTTPS transports:
+
+```java
+public interface GerritConnectionConfig2 extends GerritConnectionConfig, RestConnectionConfig {
+    // Watchdog
+    int getWatchdogTimeoutMinutes();
+    int getWatchdogTimeoutSeconds();
+    WatchTimeExceptionData getExceptionData();
+
+    // HTTPS polling (new in 2.22)
+    boolean isUseHttpsPoller();       // Enable HTTPS polling instead of SSH
+    int getHttpsPollInterval();       // Poll interval in seconds (default 10)
+    int getHttpsPollMaxChanges();     // Max changes per poll (default 100)
+}
+```
+
+Default values are defined in `GerritDefaultValues`:
+- `DEFAULT_USE_HTTPS_POLLER` = `false`
+- `DEFAULT_HTTPS_POLL_INTERVAL` = `10`
+- `DEFAULT_HTTPS_POLL_MAX_CHANGES` = `100`
+
 # Usage
 A "real life" example of usage can be found in the [Jenkins Plugin](https://github.com/jenkinsci/gerrit-trigger-plugin/blob/master/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java#L408).
 
@@ -61,6 +164,7 @@ All event types can be found in the [com.sonymobile.tools.gerrit.gerritevents.dt
         * `maven-3.5.4`
 
 Java 8 & 9: Works.
+Java 21: Works (requires `--add-opens` JVM args for PowerMock tests).
 
 The maintainers' development, tests and production environments are
 Ubuntu 12.04 so we have no means of detecting or fixing any Windows issues,

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,7 @@
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
                     <reuseForks>false</reuseForks>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
@@ -56,7 +56,7 @@ import com.sonymobile.tools.gerrit.gerritevents.watchdog.WatchTimeExceptionData;
  *
  * @author rinrinne &lt;rinrin.ne@gmail.com&gt;
  */
-public class GerritConnection extends Thread implements Connector {
+public class GerritConnection extends Thread implements Connector, GerritEventSource {
 
     /**
      * Time to wait between connection attempts.

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnection.java
@@ -489,10 +489,9 @@ public class GerritConnection extends Thread implements Connector, GerritEventSo
                 logger.error("ConnectionException: ", sshConEx);
             } catch (SshAuthenticationException sshAuthEx) {
                 logger.error("Could not authenticate to Gerrit server!"
-                        + "\n\tUsername: {}\n\tKeyFile: {}\n\tPassword: {}",
+                        + "\n\tUsername: {}\n\tKeyFile: {}",
                         new Object[]{authentication.getUsername(),
-                                authentication.getPrivateKeyFile(),
-                                authentication.getPrivateKeyFilePassword(), });
+                                authentication.getPrivateKeyFile(), });
                 logger.error("AuthenticationException: ", sshAuthEx);
             } catch (IOException ex) {
                 logger.error("Could not connect to Gerrit server! "

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnectionConfig2.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritConnectionConfig2.java
@@ -54,4 +54,32 @@ public interface GerritConnectionConfig2 extends GerritConnectionConfig, RestCon
      * @return the WatchTimeExceptionData.
      */
     WatchTimeExceptionData getExceptionData();
+
+    /**
+     * Whether HTTPS polling should be used instead of SSH stream-events
+     * for receiving Gerrit events.
+     *
+     * @return true if HTTPS polling is enabled. Default is false (use SSH).
+     */
+    default boolean isUseHttpsPoller() {
+        return GerritDefaultValues.DEFAULT_USE_HTTPS_POLLER;
+    }
+
+    /**
+     * The interval in seconds between HTTPS polls for new changes.
+     *
+     * @return the poll interval in seconds. Default is 10 seconds.
+     */
+    default int getHttpsPollInterval() {
+        return GerritDefaultValues.DEFAULT_HTTPS_POLL_INTERVAL;
+    }
+
+    /**
+     * The maximum number of changes to fetch per HTTPS poll.
+     *
+     * @return the maximum number of changes. Default is 100.
+     */
+    default int getHttpsPollMaxChanges() {
+        return GerritDefaultValues.DEFAULT_HTTPS_POLL_MAX_CHANGES;
+    }
 }

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritDefaultValues.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritDefaultValues.java
@@ -109,4 +109,19 @@ public final class GerritDefaultValues {
      * The minimum refresh interval for dynamic configuration.
      */
     public static final int MINIMUM_DYNAMIC_CONFIG_REFRESH_INTERVAL = 5;
+
+    /**
+     * Default value for whether HTTPS polling should be used instead of SSH stream-events.
+     */
+    public static final boolean DEFAULT_USE_HTTPS_POLLER = false;
+
+    /**
+     * Default poll interval in seconds for the HTTPS poller.
+     */
+    public static final int DEFAULT_HTTPS_POLL_INTERVAL = 10;
+
+    /**
+     * Default maximum number of changes to fetch per HTTPS poll.
+     */
+    public static final int DEFAULT_HTTPS_POLL_MAX_CHANGES = 100;
 }

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritEventSource.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritEventSource.java
@@ -1,0 +1,91 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2026 Amarula Solutions All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.tools.gerrit.gerritevents;
+
+/**
+ * Interface for a source of Gerrit events. Implementations are responsible for
+ * connecting to a Gerrit server and feeding events to a {@link GerritHandler}.
+ *
+ * <p>This abstraction allows different transport mechanisms (SSH stream-events,
+ * HTTPS polling, etc.) to be used interchangeably by the event consumer.</p>
+ *
+ * @author Michael Trimarchi
+ */
+public interface GerritEventSource {
+
+    /**
+     * Sets the Gerrit handler that will process received events.
+     *
+     * @param handler the handler
+     */
+    void setHandler(GerritHandler handler);
+
+    /**
+     * Gets the Gerrit handler.
+     *
+     * @return the handler
+     */
+    GerritHandler getHandler();
+
+    /**
+     * Adds a connection listener.
+     *
+     * @param listener the listener
+     */
+    void addListener(ConnectionListener listener);
+
+    /**
+     * Removes a connection listener.
+     *
+     * @param listener the listener
+     */
+    void removeListener(ConnectionListener listener);
+
+    /**
+     * Returns whether this event source is currently connected and receiving events.
+     *
+     * @return true if connected
+     */
+    boolean isConnected();
+
+    /**
+     * Returns the version of the connected Gerrit server.
+     *
+     * @return the Gerrit version string, or null if not connected
+     */
+    String getGerritVersion();
+
+    /**
+     * Shuts down this event source.
+     *
+     * @param join if true, waits for the underlying thread to finish before returning
+     */
+    void shutdown(boolean join);
+
+    /**
+     * Starts this event source. Typically implemented by delegating to the
+     * underlying thread's start method.
+     */
+    void start();
+}

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -905,14 +905,22 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
 
     /**
      * Creates a Provider for the current connection.
+     *
+     * <p>When the configured hostname is empty (e.g. SSH is not in use), the host
+     * is derived from {@code frontEndUrl} — which is the HTTPS endpoint configured
+     * for this connection.</p>
      * @return a new Provider.
      */
     private Provider createProvider() {
         //CS IGNORE AvoidInlineConditionals FOR NEXT 1 LINES. REASON: Readable null check.
         String version = gerritVersion != null ? gerritVersion : "";
+        String host = config.getGerritHostName();
+        if (host == null || host.isEmpty()) {
+            host = frontEndUrl;
+        }
         return new Provider(
                 gerritName,
-                config.getGerritHostName(),
+                host,
                 String.valueOf(config.getGerritSshPort()),
                 GERRIT_PROTOCOL_SCHEME_NAME,
                 frontEndUrl,

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -437,7 +437,14 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
             }
             try {
                 JSONObject changeJson = changes.getJSONObject(i);
-                String changeId = changeJson.getString("id");
+                // Use hex Change-Id (change_id) as key, not the REST "id" triple.
+                // This must match the key used in processChange() / knownChanges.
+                String changeId;
+                if (changeJson.has("change_id")) {
+                    changeId = changeJson.getString("change_id");
+                } else {
+                    changeId = changeJson.getString("id");
+                }
                 seenChangeIds.add(changeId);
                 processChange(changeJson, provider);
             } catch (Exception ex) {
@@ -724,6 +731,13 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
         // Fixup: REST API uses "_number" (int), not "number" (string)
         String changeNumber = String.valueOf(changeJson.optInt("_number", -1));
         change.setNumber(changeNumber);
+
+        // Fixup: REST API "id" is the full "project~changeNumber" triple.
+        // Use the hex "change_id" instead, so ChangeId.asUrlPart() produces
+        // the valid project~branch~ChangeIdHex triple for Gerrit URLs.
+        if (changeJson.has("change_id")) {
+            change.setId(changeJson.getString("change_id"));
+        }
 
         // Fixup: REST API uses "work_in_progress", not "wip"
         change.setWip(changeJson.optBoolean("work_in_progress", false));

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -129,6 +129,14 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
     private HttpClient httpClient;
 
     /**
+     * True after the first successful poll has seeded the baseline state.
+     * When false, {@link #processChange} silently populates
+     * {@link #knownChanges} without emitting events, preventing all open
+     * changes from re-firing PatchsetCreated after a restart.
+     */
+    private volatile boolean firstPollDone;
+
+    /**
      * Tracks the last known state of each change.
      * Key: changeId, Value: {revision, status}
      */
@@ -232,8 +240,10 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
 
     @Override
     public void reconnect() {
-        logger.debug("{}: Reconnect requested; resetting known changes cache.", gerritName);
-        knownChanges.clear();
+        // On the next poll, re-seed the baseline silently so that
+        // existing open changes aren't replayed as PatchsetCreated.
+        firstPollDone = false;
+        logger.debug("{}: Reconnect requested; will re-seed baseline on next poll.", gerritName);
     }
 
     // ---- Thread main loop ----
@@ -441,6 +451,8 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
         // in the current poll response). This prevents unbounded memory
         // growth from accumulating closed changes.
         pruneStaleEntries(seenChangeIds);
+
+        firstPollDone = true;
     }
 
     /**
@@ -512,6 +524,15 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
         }
 
         ChangeState previous = knownChanges.get(changeId);
+
+        // On the first poll after startup, silently seed the baseline state.
+        // This prevents all open changes from re-firing PatchsetCreated after
+        // a restart while still populating knownChanges for delta detection.
+        if (!firstPollDone) {
+            knownChanges.put(changeId, new ChangeState(currentRevision, change.getStatus(),
+                    change.getTopic(), change.isWip(), change.isPrivate()));
+            return;
+        }
 
         // Check if this is a new change or the revision has changed
         boolean isNew = (previous == null);

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -232,7 +232,7 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
 
     @Override
     public void reconnect() {
-        logger.info("{}: Reconnect requested; resetting known changes cache.", gerritName);
+        logger.debug("{}: Reconnect requested; resetting known changes cache.", gerritName);
         knownChanges.clear();
     }
 
@@ -531,7 +531,7 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
                 handler.post(event);
                 //CS IGNORE AvoidInlineConditionals FOR NEXT 1 LINES. REASON: Readable ternary.
                 String changeType = isNew ? "(new)" : "(updated)";
-                logger.info("{}: Posted PatchsetCreated for change {}/{} rev {} {}",
+                logger.debug("{}: Posted PatchsetCreated for change {}/{} rev {} {}",
                         gerritName, change.getProject(), change.getNumber(),
                         currentRevision, changeType);
             }
@@ -556,7 +556,7 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
             }
             if (statusEvent != null && handler != null) {
                 handler.post(statusEvent);
-                logger.info("{}: Posted status transition for change {}/{}: {} -> {}",
+                logger.debug("{}: Posted status transition for change {}/{}: {} -> {}",
                         gerritName, change.getProject(), change.getNumber(),
                         previous.status, change.getStatus());
             }
@@ -611,7 +611,7 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
             }
             if (handler != null) {
                 handler.post(topicEvent);
-                logger.info("{}: Posted TopicChanged for change {}/{}: {} -> {}",
+                logger.debug("{}: Posted TopicChanged for change {}/{}: {} -> {}",
                         gerritName, change.getProject(), change.getNumber(),
                         previousTopic, currentTopic);
             }
@@ -646,7 +646,7 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
         event.setAccount(change.getOwner());
         if (handler != null) {
             handler.post(event);
-            logger.info("{}: Posted WipStateChanged for change {}/{}: {} -> {}",
+            logger.debug("{}: Posted WipStateChanged for change {}/{}: {} -> {}",
                     gerritName, change.getProject(), change.getNumber(),
                     previous.wip, currentWip);
         }
@@ -680,7 +680,7 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
         event.setAccount(change.getOwner());
         if (handler != null) {
             handler.post(event);
-            logger.info("{}: Posted PrivateStateChanged for change {}/{}: {} -> {}",
+            logger.debug("{}: Posted PrivateStateChanged for change {}/{}: {} -> {}",
                     gerritName, change.getProject(), change.getNumber(),
                     previous.isPrivate, currentPrivate);
         }

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -31,6 +31,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -402,6 +404,7 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
 
         logger.debug("{}: Processing {} open changes.", gerritName, changes.size());
         Provider provider = createProvider();
+        Set<String> seenChangeIds = new HashSet<String>();
 
         for (int i = 0; i < changes.size(); i++) {
             if (shutdownInProgress || interrupted()) {
@@ -409,10 +412,45 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
             }
             try {
                 JSONObject changeJson = changes.getJSONObject(i);
+                String changeId = changeJson.getString("id");
+                seenChangeIds.add(changeId);
                 processChange(changeJson, provider);
             } catch (Exception ex) {
                 logger.warn("{}: Error processing change at index {}: {}",
                         gerritName, i, ex.getMessage());
+            }
+        }
+
+        // Prune stale entries: remove changes that are no longer open
+        // (MERGED, ABANDONED, or UNKNOWN — e.g. DELETED — and not present
+        // in the current poll response). This prevents unbounded memory
+        // growth from accumulating closed changes.
+        pruneStaleEntries(seenChangeIds);
+    }
+
+    /**
+     * Removes entries from {@link #knownChanges} whose status is MERGED,
+     * ABANDONED, or UNKNOWN (e.g. DELETED) and that are not present in
+     * the given set of seen change IDs. NEW entries are never pruned,
+     * even if absent from the current poll (pagination safety).
+     *
+     * <p>Package visibility for testing.</p>
+     *
+     * @param seenChangeIds the set of change IDs present in the current poll.
+     */
+    void pruneStaleEntries(Set<String> seenChangeIds) {
+        Iterator<Map.Entry<String, ChangeState>> it = knownChanges.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, ChangeState> entry = it.next();
+            if (seenChangeIds.contains(entry.getKey())) {
+                continue;
+            }
+            GerritChangeStatus status = entry.getValue().status;
+            if (status == GerritChangeStatus.MERGED
+                    || status == GerritChangeStatus.ABANDONED
+                    || status == GerritChangeStatus.UNKNOWN) {
+                it.remove();
+                logger.trace("{}: Pruned stale entry for change {}", gerritName, entry.getKey());
             }
         }
     }

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -27,8 +27,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Date;
@@ -43,18 +41,13 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
 
-import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.Credentials;
-import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.sonymobile.tools.gerrit.gerritevents.helpers.HttpClientFactory;
 
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeKind;
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeStatus;
@@ -325,32 +318,8 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
      * @return a configured HttpClient.
      */
     private HttpClient createHttpClient() {
-        Credentials creds = config.getHttpCredentials();
-        CredentialsProvider credsProvider = new BasicCredentialsProvider();
-        credsProvider.setCredentials(AuthScope.ANY, creds);
-        HttpClientBuilder builder = HttpClients.custom()
-                .setDefaultCredentialsProvider(credsProvider);
-        configureProxy(builder);
-        return builder.build();
-    }
-
-    /**
-     * Configures an HTTP proxy on the given client builder if a proxy is
-     * defined in the configuration.
-     *
-     * @param builder the HttpClientBuilder to configure.
-     */
-    private void configureProxy(HttpClientBuilder builder) {
-        String proxyUrl = config.getGerritProxy();
-        if (proxyUrl != null && !proxyUrl.isEmpty()) {
-            try {
-                URL url = new URL(proxyUrl);
-                builder.setProxy(new HttpHost(url.getHost(), url.getPort(), url.getProtocol()));
-            } catch (MalformedURLException e) {
-                logger.warn("{}: Could not parse HTTP proxy URL, proceeding without proxy: {}",
-                        gerritName, e.getMessage());
-            }
-        }
+        return HttpClientFactory.createClient(
+                config.getHttpCredentials(), config.getGerritProxy());
     }
 
     /**

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -384,7 +384,7 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
      */
     private void pollChanges() throws IOException {
         String queryPath = "a/changes/?q=is:open&n=" + maxChangesPerPoll
-                + "&o=CURRENT_REVISION&o=DETAILED_ACCOUNTS&o=CURRENT_COMMIT&o=HASHTAGS";
+                + "&o=CURRENT_REVISION&o=DETAILED_ACCOUNTS&o=CURRENT_COMMIT";
         String body = httpGet(queryPath);
         JSONArray changes;
         try {

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -63,6 +63,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeMerged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PrivateStateChanged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.WipStateChanged;
 
 /**
@@ -141,6 +142,8 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
         final String topic;
         /** Whether the change is work-in-progress. */
         final boolean wip;
+        /** Whether the change is private. */
+        final boolean isPrivate;
 
         /**
          * Creates a new ChangeState.
@@ -148,12 +151,14 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
          * @param status the status.
          * @param topic the topic, or null.
          * @param wip whether the change is work-in-progress.
+         * @param isPrivate whether the change is private.
          */
-        ChangeState(String revision, GerritChangeStatus status, String topic, boolean wip) {
+        ChangeState(String revision, GerritChangeStatus status, String topic, boolean wip, boolean isPrivate) {
             this.revision = revision;
             this.status = status;
             this.topic = topic;
             this.wip = wip;
+            this.isPrivate = isPrivate;
         }
     }
 
@@ -524,17 +529,25 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
                     subject, changeNumber, changeStatus);
         }
 
-        // Extract current topic and WIP from the REST response for state tracking
+        // Check for private state change on known changes
+        if (previous != null && !isNew && !revisionChanged) {
+            detectPrivateStateChange(changeJson, previous, provider,
+                    currentRevObj, currentRevision, changeId, project, branch,
+                    subject, changeNumber, changeStatus);
+        }
+
+        // Extract current topic, WIP and private state from the REST response for state tracking
         String currentTopic = changeJson.optString("topic", null);
         if (currentTopic != null && currentTopic.isEmpty()) {
             currentTopic = null;
         }
 
         boolean currentWip = changeJson.optBoolean("work_in_progress", false);
+        boolean currentPrivate = changeJson.optBoolean("is_private", false);
 
         // Update known state
         knownChanges.put(changeId, new ChangeState(currentRevision, changeStatus,
-                currentTopic, currentWip));
+                currentTopic, currentWip, currentPrivate));
     }
 
     /**
@@ -645,6 +658,57 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
             handler.post(event);
             logger.info("{}: Posted WipStateChanged for change {}/{}: {} -> {}",
                     gerritName, project, changeNumber, previous.wip, currentWip);
+        }
+    }
+
+    /**
+     * Detects private state changes for a known change and emits
+     * a {@link PrivateStateChanged} event when the private state toggles.
+     *
+     * @param changeJson the REST API JSON for the change.
+     * @param previous the previous known state.
+     * @param provider the Provider to attach.
+     * @param currentRevObj the current revision JSON.
+     * @param currentRevision the current revision SHA.
+     * @param changeId the change ID.
+     * @param project the project name.
+     * @param branch the branch name.
+     * @param subject the change subject.
+     * @param changeNumber the change number.
+     * @param changeStatus the current status.
+     */
+    private void detectPrivateStateChange(JSONObject changeJson, ChangeState previous,
+            Provider provider, JSONObject currentRevObj, String currentRevision,
+            String changeId, String project, String branch, String subject,
+            String changeNumber, GerritChangeStatus changeStatus) {
+
+        boolean currentPrivate = changeJson.optBoolean("is_private", false);
+        if (previous.isPrivate == currentPrivate) {
+            return;
+        }
+
+        Change change = buildChange(changeJson, changeId, project, branch, subject,
+                changeNumber, changeStatus);
+        change.setPrivate(currentPrivate);
+        PatchSet patchSet = buildPatchSet(currentRevObj, currentRevision);
+
+        PrivateStateChanged event = new PrivateStateChanged();
+        event.setChange(change);
+        event.setPatchset(patchSet);
+        event.setProvider(provider);
+        event.setReceivedOn(System.currentTimeMillis());
+        if (changeJson.has("owner")) {
+            try {
+                event.setAccount(new Account(changeJson.getJSONObject("owner")));
+            } catch (Exception ex) {
+                logger.trace("{}: Could not parse owner for private state change: {}",
+                        gerritName, ex.getMessage());
+            }
+        }
+        if (handler != null) {
+            handler.post(event);
+            logger.info("{}: Posted PrivateStateChanged for change {}/{}: {} -> {}",
+                    gerritName, project, changeNumber, previous.isPrivate, currentPrivate);
         }
     }
 

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -27,6 +27,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,6 +45,7 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
 
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
@@ -50,6 +53,7 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -316,9 +320,29 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
         Credentials creds = config.getHttpCredentials();
         CredentialsProvider credsProvider = new BasicCredentialsProvider();
         credsProvider.setCredentials(AuthScope.ANY, creds);
-        return HttpClients.custom()
-                .setDefaultCredentialsProvider(credsProvider)
-                .build();
+        HttpClientBuilder builder = HttpClients.custom()
+                .setDefaultCredentialsProvider(credsProvider);
+        configureProxy(builder);
+        return builder.build();
+    }
+
+    /**
+     * Configures an HTTP proxy on the given client builder if a proxy is
+     * defined in the configuration.
+     *
+     * @param builder the HttpClientBuilder to configure.
+     */
+    private void configureProxy(HttpClientBuilder builder) {
+        String proxyUrl = config.getGerritProxy();
+        if (proxyUrl != null && !proxyUrl.isEmpty()) {
+            try {
+                URL url = new URL(proxyUrl);
+                builder.setProxy(new HttpHost(url.getHost(), url.getPort(), url.getProtocol()));
+            } catch (MalformedURLException e) {
+                logger.warn("{}: Could not parse HTTP proxy URL, proceeding without proxy: {}",
+                        gerritName, e.getMessage());
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -63,6 +63,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeMerged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.WipStateChanged;
 
 /**
  * Polls the Gerrit REST API over HTTPS to receive change events.
@@ -138,17 +139,21 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
         final GerritChangeStatus status;
         /** The last known topic, or null. */
         final String topic;
+        /** Whether the change is work-in-progress. */
+        final boolean wip;
 
         /**
          * Creates a new ChangeState.
          * @param revision the revision.
          * @param status the status.
          * @param topic the topic, or null.
+         * @param wip whether the change is work-in-progress.
          */
-        ChangeState(String revision, GerritChangeStatus status, String topic) {
+        ChangeState(String revision, GerritChangeStatus status, String topic, boolean wip) {
             this.revision = revision;
             this.status = status;
             this.topic = topic;
+            this.wip = wip;
         }
     }
 
@@ -512,15 +517,24 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
                     subject, changeNumber, changeStatus);
         }
 
-        // Extract current topic from the REST response for state tracking
+        // Check for WIP state change on known changes
+        if (previous != null && !isNew && !revisionChanged) {
+            detectWipStateChange(changeJson, previous, provider,
+                    currentRevObj, currentRevision, changeId, project, branch,
+                    subject, changeNumber, changeStatus);
+        }
+
+        // Extract current topic and WIP from the REST response for state tracking
         String currentTopic = changeJson.optString("topic", null);
         if (currentTopic != null && currentTopic.isEmpty()) {
             currentTopic = null;
         }
 
+        boolean currentWip = changeJson.optBoolean("work_in_progress", false);
+
         // Update known state
         knownChanges.put(changeId, new ChangeState(currentRevision, changeStatus,
-                currentTopic));
+                currentTopic, currentWip));
     }
 
     /**
@@ -580,6 +594,57 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
                 logger.info("{}: Posted TopicChanged for change {}/{}: {} -> {}",
                         gerritName, project, changeNumber, previousTopic, currentTopic);
             }
+        }
+    }
+
+    /**
+     * Detects WIP (Work In Progress) state changes for a known change and emits
+     * a {@link WipStateChanged} event when the WIP state toggles.
+     *
+     * @param changeJson the REST API JSON for the change.
+     * @param previous the previous known state.
+     * @param provider the Provider to attach.
+     * @param currentRevObj the current revision JSON.
+     * @param currentRevision the current revision SHA.
+     * @param changeId the change ID.
+     * @param project the project name.
+     * @param branch the branch name.
+     * @param subject the change subject.
+     * @param changeNumber the change number.
+     * @param changeStatus the current status.
+     */
+    private void detectWipStateChange(JSONObject changeJson, ChangeState previous,
+            Provider provider, JSONObject currentRevObj, String currentRevision,
+            String changeId, String project, String branch, String subject,
+            String changeNumber, GerritChangeStatus changeStatus) {
+
+        boolean currentWip = changeJson.optBoolean("work_in_progress", false);
+        if (previous.wip == currentWip) {
+            return;
+        }
+
+        Change change = buildChange(changeJson, changeId, project, branch, subject,
+                changeNumber, changeStatus);
+        change.setWip(currentWip);
+        PatchSet patchSet = buildPatchSet(currentRevObj, currentRevision);
+
+        WipStateChanged event = new WipStateChanged();
+        event.setChange(change);
+        event.setPatchset(patchSet);
+        event.setProvider(provider);
+        event.setReceivedOn(System.currentTimeMillis());
+        if (changeJson.has("owner")) {
+            try {
+                event.setAccount(new Account(changeJson.getJSONObject("owner")));
+            } catch (Exception ex) {
+                logger.trace("{}: Could not parse owner for WIP change: {}",
+                        gerritName, ex.getMessage());
+            }
+        }
+        if (handler != null) {
+            handler.post(event);
+            logger.info("{}: Posted WipStateChanged for change {}/{}: {} -> {}",
+                    gerritName, project, changeNumber, previous.wip, currentWip);
         }
     }
 

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -28,8 +28,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -60,6 +62,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeAbandoned;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeMerged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
 
 /**
  * Polls the Gerrit REST API over HTTPS to receive change events.
@@ -126,25 +129,26 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
     private final Map<String, ChangeState> knownChanges = new ConcurrentHashMap<String, ChangeState>();
 
     /**
-     * Stores the last known revision and status for a change.
-     */
-    /**
-     * Stores the last known revision and status for a change.
+     * Stores the last known state for a change.
      */
     private static class ChangeState {
         /** The last known revision. */
         final String revision;
         /** The last known status. */
         final GerritChangeStatus status;
+        /** The last known topic, or null. */
+        final String topic;
 
         /**
          * Creates a new ChangeState.
          * @param revision the revision.
          * @param status the status.
+         * @param topic the topic, or null.
          */
-        ChangeState(String revision, GerritChangeStatus status) {
+        ChangeState(String revision, GerritChangeStatus status, String topic) {
             this.revision = revision;
             this.status = status;
+            this.topic = topic;
         }
     }
 
@@ -370,7 +374,7 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
      */
     private void pollChanges() throws IOException {
         String queryPath = "a/changes/?q=is:open&n=" + maxChangesPerPoll
-                + "&o=CURRENT_REVISION&o=DETAILED_ACCOUNTS&o=CURRENT_COMMIT";
+                + "&o=CURRENT_REVISION&o=DETAILED_ACCOUNTS&o=CURRENT_COMMIT&o=HASHTAGS";
         String body = httpGet(queryPath);
         JSONArray changes;
         try {
@@ -501,8 +505,82 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
             }
         }
 
+        // Check for topic changes on known changes
+        if (previous != null && !isNew && !revisionChanged) {
+            detectTopicChange(changeJson, previous, provider,
+                    currentRevObj, currentRevision, changeId, project, branch,
+                    subject, changeNumber, changeStatus);
+        }
+
+        // Extract current topic from the REST response for state tracking
+        String currentTopic = changeJson.optString("topic", null);
+        if (currentTopic != null && currentTopic.isEmpty()) {
+            currentTopic = null;
+        }
+
         // Update known state
-        knownChanges.put(changeId, new ChangeState(currentRevision, changeStatus));
+        knownChanges.put(changeId, new ChangeState(currentRevision, changeStatus,
+                currentTopic));
+    }
+
+    /**
+     * Detects topic changes for a known change and emits a
+     * {@link TopicChanged} event when the topic changes.
+     *
+     * @param changeJson the REST API JSON for the change.
+     * @param previous the previous known state.
+     * @param provider the Provider to attach.
+     * @param currentRevObj the current revision JSON.
+     * @param currentRevision the current revision SHA.
+     * @param changeId the change ID.
+     * @param project the project name.
+     * @param branch the branch name.
+     * @param subject the change subject.
+     * @param changeNumber the change number.
+     * @param changeStatus the current status.
+     */
+    private void detectTopicChange(JSONObject changeJson, ChangeState previous,
+            Provider provider, JSONObject currentRevObj, String currentRevision,
+            String changeId, String project, String branch, String subject,
+            String changeNumber, GerritChangeStatus changeStatus) {
+
+        String currentTopic = changeJson.optString("topic", null);
+        if (currentTopic != null && currentTopic.isEmpty()) {
+            currentTopic = null;
+        }
+        String previousTopic = previous.topic;
+
+        //CS IGNORE AvoidInlineConditionals FOR NEXT 2 LINES. REASON: Readable null-safe.
+        boolean topicChanged = (previousTopic == null)
+                ? (currentTopic != null) : !previousTopic.equals(currentTopic);
+        if (topicChanged) {
+            Change change = buildChange(changeJson, changeId, project, branch, subject,
+                    changeNumber, changeStatus);
+            PatchSet patchSet = buildPatchSet(currentRevObj, currentRevision);
+
+            TopicChanged topicEvent = new TopicChanged();
+            topicEvent.setChange(change);
+            topicEvent.setPatchset(patchSet);
+            topicEvent.setProvider(provider);
+            topicEvent.setReceivedOn(System.currentTimeMillis());
+            if (previousTopic != null) {
+                topicEvent.setOldTopic(previousTopic);
+            }
+            if (changeJson.has("owner")) {
+                try {
+                    topicEvent.setChanger(new Account(changeJson.getJSONObject("owner")));
+                    topicEvent.setAccount(new Account(changeJson.getJSONObject("owner")));
+                } catch (Exception ex) {
+                    logger.trace("{}: Could not parse changer for topic change: {}",
+                            gerritName, ex.getMessage());
+                }
+            }
+            if (handler != null) {
+                handler.post(topicEvent);
+                logger.info("{}: Posted TopicChanged for change {}/{}: {} -> {}",
+                        gerritName, project, changeNumber, previousTopic, currentTopic);
+            }
+        }
     }
 
     /**
@@ -535,6 +613,21 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
         // Set URL
         String url = frontEndUrl + changeNumber;
         change.setUrl(url);
+        // Set topic if present
+        if (changeJson.has("topic")) {
+            change.setTopic(changeJson.getString("topic"));
+        }
+        // Set hashtags if present
+        if (changeJson.has("hashtags")) {
+            JSONArray tags = changeJson.getJSONArray("hashtags");
+            List<String> hashtagList = new ArrayList<String>(tags.size());
+            for (int j = 0; j < tags.size(); j++) {
+                hashtagList.add(tags.getString(j));
+            }
+            change.setHashtags(hashtagList);
+        } else {
+            change.setHashtags(Collections.<String>emptyList());
+        }
         return change;
     }
 

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -30,12 +30,10 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -480,13 +478,9 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
      * @param provider the Provider to attach to events.
      */
     private void processChange(JSONObject changeJson, Provider provider) {
-        String changeId = changeJson.getString("id");
-        String project = changeJson.getString("project");
-        String branch = changeJson.optString("branch", "");
-        String subject = changeJson.optString("subject", "");
-        String changeNumber = String.valueOf(changeJson.optInt("_number", -1));
-        String status = changeJson.optString("status", "NEW");
-        GerritChangeStatus changeStatus = GerritChangeStatus.fromString(status);
+        // Build the Change DTO once — reused by all event-detection branches
+        Change change = buildChange(changeJson);
+        String changeId = change.getId();
 
         // Determine current revision
         String currentRevision = null;
@@ -506,6 +500,17 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
             return;
         }
 
+        // Extract abandoner (only available from raw JSON, not on Change DTO)
+        Account abandoner = null;
+        if (changeJson.has("abandoner")) {
+            try {
+                abandoner = new Account(changeJson.getJSONObject("abandoner"));
+            } catch (Exception ex) {
+                logger.trace("{}: Could not parse abandoner for change {}: {}",
+                        gerritName, changeId, ex.getMessage());
+            }
+        }
+
         ChangeState previous = knownChanges.get(changeId);
 
         // Check if this is a new change or the revision has changed
@@ -513,50 +518,36 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
         boolean revisionChanged = (previous != null && !currentRevision.equals(previous.revision));
 
         if (isNew || revisionChanged) {
-            // Build Change and PatchSet DTOs
-            Change change = buildChange(changeJson, changeId, project, branch, subject,
-                    changeNumber, changeStatus);
             PatchSet patchSet = buildPatchSet(currentRevObj, currentRevision);
 
-            // Build PatchsetCreated event
             PatchsetCreated event = new PatchsetCreated();
             event.setChange(change);
             event.setPatchset(patchSet);
             event.setProvider(provider);
             event.setReceivedOn(System.currentTimeMillis());
-
-            // Set the account from owner
-            if (changeJson.has("owner")) {
-                try {
-                    event.setAccount(new Account(changeJson.getJSONObject("owner")));
-                } catch (Exception ex) {
-                    logger.trace("{}: Could not parse owner for change {}: {}",
-                            gerritName, changeId, ex.getMessage());
-                }
-            }
+            event.setAccount(change.getOwner());
 
             if (handler != null) {
                 handler.post(event);
                 //CS IGNORE AvoidInlineConditionals FOR NEXT 1 LINES. REASON: Readable ternary.
                 String changeType = isNew ? "(new)" : "(updated)";
                 logger.info("{}: Posted PatchsetCreated for change {}/{} rev {} {}",
-                        gerritName, project, changeNumber, currentRevision, changeType);
+                        gerritName, change.getProject(), change.getNumber(),
+                        currentRevision, changeType);
             }
         }
 
         // Check for status transitions on known changes
-        if (previous != null && previous.status != changeStatus) {
+        if (previous != null && previous.status != change.getStatus()) {
             GerritTriggeredEvent statusEvent = null;
-            switch (changeStatus) {
+            switch (change.getStatus()) {
                 case MERGED:
-                    statusEvent = buildStatusEvent(changeJson, project, branch, subject,
-                            changeNumber, currentRevision, currentRevObj, provider,
-                            ChangeMerged.class);
+                    statusEvent = buildStatusEvent(change, currentRevision, currentRevObj,
+                            provider, abandoner, ChangeMerged.class);
                     break;
                 case ABANDONED:
-                    statusEvent = buildStatusEvent(changeJson, project, branch, subject,
-                            changeNumber, currentRevision, currentRevObj, provider,
-                            ChangeAbandoned.class);
+                    statusEvent = buildStatusEvent(change, currentRevision, currentRevObj,
+                            provider, abandoner, ChangeAbandoned.class);
                     break;
                 default:
                     // RESTORED status is not directly distinguishable from NEW
@@ -566,78 +557,43 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
             if (statusEvent != null && handler != null) {
                 handler.post(statusEvent);
                 logger.info("{}: Posted status transition for change {}/{}: {} -> {}",
-                        gerritName, project, changeNumber, previous.status, changeStatus);
+                        gerritName, change.getProject(), change.getNumber(),
+                        previous.status, change.getStatus());
             }
         }
 
-        // Check for topic changes on known changes
+        // Check for topic/WIP/private changes on known changes
         if (previous != null && !isNew && !revisionChanged) {
-            detectTopicChange(changeJson, previous, provider,
-                    currentRevObj, currentRevision, changeId, project, branch,
-                    subject, changeNumber, changeStatus);
+            detectTopicChange(change, previous, provider, currentRevObj, currentRevision);
+            detectWipStateChange(change, previous, provider, currentRevObj, currentRevision);
+            detectPrivateStateChange(change, previous, provider, currentRevObj, currentRevision);
         }
 
-        // Check for WIP state change on known changes
-        if (previous != null && !isNew && !revisionChanged) {
-            detectWipStateChange(changeJson, previous, provider,
-                    currentRevObj, currentRevision, changeId, project, branch,
-                    subject, changeNumber, changeStatus);
-        }
-
-        // Check for private state change on known changes
-        if (previous != null && !isNew && !revisionChanged) {
-            detectPrivateStateChange(changeJson, previous, provider,
-                    currentRevObj, currentRevision, changeId, project, branch,
-                    subject, changeNumber, changeStatus);
-        }
-
-        // Extract current topic, WIP and private state from the REST response for state tracking
-        String currentTopic = changeJson.optString("topic", null);
-        if (currentTopic != null && currentTopic.isEmpty()) {
-            currentTopic = null;
-        }
-
-        boolean currentWip = changeJson.optBoolean("work_in_progress", false);
-        boolean currentPrivate = changeJson.optBoolean("is_private", false);
-
-        // Update known state
-        knownChanges.put(changeId, new ChangeState(currentRevision, changeStatus,
-                currentTopic, currentWip, currentPrivate));
+        // Update known state from the Change DTO
+        knownChanges.put(changeId, new ChangeState(currentRevision, change.getStatus(),
+                change.getTopic(), change.isWip(), change.isPrivate()));
     }
 
     /**
      * Detects topic changes for a known change and emits a
      * {@link TopicChanged} event when the topic changes.
      *
-     * @param changeJson the REST API JSON for the change.
+     * @param change the pre-built Change DTO.
      * @param previous the previous known state.
      * @param provider the Provider to attach.
      * @param currentRevObj the current revision JSON.
      * @param currentRevision the current revision SHA.
-     * @param changeId the change ID.
-     * @param project the project name.
-     * @param branch the branch name.
-     * @param subject the change subject.
-     * @param changeNumber the change number.
-     * @param changeStatus the current status.
      */
-    private void detectTopicChange(JSONObject changeJson, ChangeState previous,
-            Provider provider, JSONObject currentRevObj, String currentRevision,
-            String changeId, String project, String branch, String subject,
-            String changeNumber, GerritChangeStatus changeStatus) {
+    private void detectTopicChange(Change change, ChangeState previous,
+            Provider provider, JSONObject currentRevObj, String currentRevision) {
 
-        String currentTopic = changeJson.optString("topic", null);
-        if (currentTopic != null && currentTopic.isEmpty()) {
-            currentTopic = null;
-        }
+        String currentTopic = change.getTopic();
         String previousTopic = previous.topic;
 
         //CS IGNORE AvoidInlineConditionals FOR NEXT 2 LINES. REASON: Readable null-safe.
         boolean topicChanged = (previousTopic == null)
                 ? (currentTopic != null) : !previousTopic.equals(currentTopic);
         if (topicChanged) {
-            Change change = buildChange(changeJson, changeId, project, branch, subject,
-                    changeNumber, changeStatus);
             PatchSet patchSet = buildPatchSet(currentRevObj, currentRevision);
 
             TopicChanged topicEvent = new TopicChanged();
@@ -648,19 +604,16 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
             if (previousTopic != null) {
                 topicEvent.setOldTopic(previousTopic);
             }
-            if (changeJson.has("owner")) {
-                try {
-                    topicEvent.setChanger(new Account(changeJson.getJSONObject("owner")));
-                    topicEvent.setAccount(new Account(changeJson.getJSONObject("owner")));
-                } catch (Exception ex) {
-                    logger.trace("{}: Could not parse changer for topic change: {}",
-                            gerritName, ex.getMessage());
-                }
+            Account owner = change.getOwner();
+            if (owner != null) {
+                topicEvent.setChanger(owner);
+                topicEvent.setAccount(owner);
             }
             if (handler != null) {
                 handler.post(topicEvent);
                 logger.info("{}: Posted TopicChanged for change {}/{}: {} -> {}",
-                        gerritName, project, changeNumber, previousTopic, currentTopic);
+                        gerritName, change.getProject(), change.getNumber(),
+                        previousTopic, currentTopic);
             }
         }
     }
@@ -669,31 +622,20 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
      * Detects WIP (Work In Progress) state changes for a known change and emits
      * a {@link WipStateChanged} event when the WIP state toggles.
      *
-     * @param changeJson the REST API JSON for the change.
+     * @param change the pre-built Change DTO.
      * @param previous the previous known state.
      * @param provider the Provider to attach.
      * @param currentRevObj the current revision JSON.
      * @param currentRevision the current revision SHA.
-     * @param changeId the change ID.
-     * @param project the project name.
-     * @param branch the branch name.
-     * @param subject the change subject.
-     * @param changeNumber the change number.
-     * @param changeStatus the current status.
      */
-    private void detectWipStateChange(JSONObject changeJson, ChangeState previous,
-            Provider provider, JSONObject currentRevObj, String currentRevision,
-            String changeId, String project, String branch, String subject,
-            String changeNumber, GerritChangeStatus changeStatus) {
+    private void detectWipStateChange(Change change, ChangeState previous,
+            Provider provider, JSONObject currentRevObj, String currentRevision) {
 
-        boolean currentWip = changeJson.optBoolean("work_in_progress", false);
+        boolean currentWip = change.isWip();
         if (previous.wip == currentWip) {
             return;
         }
 
-        Change change = buildChange(changeJson, changeId, project, branch, subject,
-                changeNumber, changeStatus);
-        change.setWip(currentWip);
         PatchSet patchSet = buildPatchSet(currentRevObj, currentRevision);
 
         WipStateChanged event = new WipStateChanged();
@@ -701,18 +643,12 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
         event.setPatchset(patchSet);
         event.setProvider(provider);
         event.setReceivedOn(System.currentTimeMillis());
-        if (changeJson.has("owner")) {
-            try {
-                event.setAccount(new Account(changeJson.getJSONObject("owner")));
-            } catch (Exception ex) {
-                logger.trace("{}: Could not parse owner for WIP change: {}",
-                        gerritName, ex.getMessage());
-            }
-        }
+        event.setAccount(change.getOwner());
         if (handler != null) {
             handler.post(event);
             logger.info("{}: Posted WipStateChanged for change {}/{}: {} -> {}",
-                    gerritName, project, changeNumber, previous.wip, currentWip);
+                    gerritName, change.getProject(), change.getNumber(),
+                    previous.wip, currentWip);
         }
     }
 
@@ -720,31 +656,20 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
      * Detects private state changes for a known change and emits
      * a {@link PrivateStateChanged} event when the private state toggles.
      *
-     * @param changeJson the REST API JSON for the change.
+     * @param change the pre-built Change DTO.
      * @param previous the previous known state.
      * @param provider the Provider to attach.
      * @param currentRevObj the current revision JSON.
      * @param currentRevision the current revision SHA.
-     * @param changeId the change ID.
-     * @param project the project name.
-     * @param branch the branch name.
-     * @param subject the change subject.
-     * @param changeNumber the change number.
-     * @param changeStatus the current status.
      */
-    private void detectPrivateStateChange(JSONObject changeJson, ChangeState previous,
-            Provider provider, JSONObject currentRevObj, String currentRevision,
-            String changeId, String project, String branch, String subject,
-            String changeNumber, GerritChangeStatus changeStatus) {
+    private void detectPrivateStateChange(Change change, ChangeState previous,
+            Provider provider, JSONObject currentRevObj, String currentRevision) {
 
-        boolean currentPrivate = changeJson.optBoolean("is_private", false);
+        boolean currentPrivate = change.isPrivate();
         if (previous.isPrivate == currentPrivate) {
             return;
         }
 
-        Change change = buildChange(changeJson, changeId, project, branch, subject,
-                changeNumber, changeStatus);
-        change.setPrivate(currentPrivate);
         PatchSet patchSet = buildPatchSet(currentRevObj, currentRevision);
 
         PrivateStateChanged event = new PrivateStateChanged();
@@ -752,66 +677,42 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
         event.setPatchset(patchSet);
         event.setProvider(provider);
         event.setReceivedOn(System.currentTimeMillis());
-        if (changeJson.has("owner")) {
-            try {
-                event.setAccount(new Account(changeJson.getJSONObject("owner")));
-            } catch (Exception ex) {
-                logger.trace("{}: Could not parse owner for private state change: {}",
-                        gerritName, ex.getMessage());
-            }
-        }
+        event.setAccount(change.getOwner());
         if (handler != null) {
             handler.post(event);
             logger.info("{}: Posted PrivateStateChanged for change {}/{}: {} -> {}",
-                    gerritName, project, changeNumber, previous.isPrivate, currentPrivate);
+                    gerritName, change.getProject(), change.getNumber(),
+                    previous.isPrivate, currentPrivate);
         }
     }
 
     /**
      * Builds a Change DTO from the REST API JSON.
+     * Uses {@link Change#fromJson} for standard fields and applies
+     * REST-API-specific fixups for fields whose key names differ from
+     * the event-stream format ({@code _number}, {@code work_in_progress},
+     * {@code is_private}, and the missing {@code url}).
+     *
      * @param changeJson the JSON object for this change.
-     * @param changeId the change ID.
-     * @param project the project name.
-     * @param branch the branch name.
-     * @param subject the change subject.
-     * @param changeNumber the change number.
-     * @param status the change status.
      * @return a new Change DTO.
      */
-    private Change buildChange(JSONObject changeJson, String changeId, String project,
-            String branch, String subject, String changeNumber, GerritChangeStatus status) {
+    private Change buildChange(JSONObject changeJson) {
         Change change = new Change();
-        change.setProject(project);
-        change.setBranch(branch);
-        change.setId(changeId);
+        change.fromJson(changeJson);
+
+        // Fixup: REST API uses "_number" (int), not "number" (string)
+        String changeNumber = String.valueOf(changeJson.optInt("_number", -1));
         change.setNumber(changeNumber);
-        change.setSubject(subject);
-        change.setStatus(status);
-        if (changeJson.has("owner")) {
-            try {
-                change.setOwner(new Account(changeJson.getJSONObject("owner")));
-            } catch (Exception ex) {
-                logger.trace("Could not set owner on change: {}", ex.getMessage());
-            }
-        }
-        // Set URL
-        String url = frontEndUrl + changeNumber;
-        change.setUrl(url);
-        // Set topic if present
-        if (changeJson.has("topic")) {
-            change.setTopic(changeJson.getString("topic"));
-        }
-        // Set hashtags if present
-        if (changeJson.has("hashtags")) {
-            JSONArray tags = changeJson.getJSONArray("hashtags");
-            List<String> hashtagList = new ArrayList<String>(tags.size());
-            for (int j = 0; j < tags.size(); j++) {
-                hashtagList.add(tags.getString(j));
-            }
-            change.setHashtags(hashtagList);
-        } else {
-            change.setHashtags(Collections.<String>emptyList());
-        }
+
+        // Fixup: REST API uses "work_in_progress", not "wip"
+        change.setWip(changeJson.optBoolean("work_in_progress", false));
+
+        // Fixup: REST API uses "is_private", not "private"
+        change.setPrivate(changeJson.optBoolean("is_private", false));
+
+        // Fixup: REST API has no "url" field — construct it
+        change.setUrl(frontEndUrl + changeNumber);
+
         return change;
     }
 
@@ -851,24 +752,17 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
 
     /**
      * Builds a status transition event (ChangeMerged, ChangeAbandoned, etc.).
-     * @param changeJson the JSON object for the change.
-     * @param project the project name.
-     * @param branch the branch name.
-     * @param subject the change subject.
-     * @param changeNumber the change number.
+     * @param change the pre-built Change DTO.
      * @param revision the current revision SHA.
      * @param revisionObj the JSON object for the revision.
      * @param provider the Provider to attach.
+     * @param abandoner the abandoner Account, or null.
      * @param eventClass the event class to build (ChangeMerged.class or ChangeAbandoned.class).
      * @return a new GerritTriggeredEvent, or null on failure.
      */
-    private GerritTriggeredEvent buildStatusEvent(JSONObject changeJson, String project,
-            String branch, String subject, String changeNumber, String revision,
-            JSONObject revisionObj, Provider provider, Class<?> eventClass) {
+    private GerritTriggeredEvent buildStatusEvent(Change change, String revision,
+            JSONObject revisionObj, Provider provider, Account abandoner, Class<?> eventClass) {
         try {
-            Change change = buildChange(changeJson, changeJson.getString("id"), project, branch,
-                    subject, changeNumber, GerritChangeStatus.fromString(
-                            changeJson.optString("status", "")));
             PatchSet patchSet = buildPatchSet(revisionObj, revision);
 
             if (eventClass == ChangeMerged.class) {
@@ -877,9 +771,7 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
                 event.setPatchset(patchSet);
                 event.setProvider(provider);
                 event.setReceivedOn(System.currentTimeMillis());
-                if (changeJson.has("owner")) {
-                    event.setAccount(new Account(changeJson.getJSONObject("owner")));
-                }
+                event.setAccount(change.getOwner());
                 return event;
             } else if (eventClass == ChangeAbandoned.class) {
                 ChangeAbandoned event = new ChangeAbandoned();
@@ -887,13 +779,9 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
                 event.setPatchset(patchSet);
                 event.setProvider(provider);
                 event.setReceivedOn(System.currentTimeMillis());
-                if (changeJson.has("owner")) {
-                    event.setAccount(new Account(changeJson.getJSONObject("owner")));
-                }
-                // Set abandoner if available
-                if (changeJson.has("abandoner")) {
-                    // Store abandoner as the account field for ChangeAbandoned
-                    event.setAbandoner(new Account(changeJson.getJSONObject("abandoner")));
+                event.setAccount(change.getOwner());
+                if (abandoner != null) {
+                    event.setAbandoner(abandoner);
                 }
                 return event;
             }

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -256,21 +256,14 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
                 }
 
                 pollChanges();
-
-                if (!connected) {
-                    notifyConnectionEstablished();
-                }
+                notifyConnectionEstablished();
             } catch (IOException ex) {
                 logger.error("{}: Error during HTTPS poll: {}", gerritName, ex.getMessage());
-                if (connected) {
-                    notifyConnectionDown();
-                }
+                notifyConnectionDown();
                 sleepMillis(ERROR_SLEEP_MILLIS);
             } catch (Exception ex) {
                 logger.error("{}: Unexpected error during poll.", gerritName, ex);
-                if (connected) {
-                    notifyConnectionDown();
-                }
+                notifyConnectionDown();
                 sleepMillis(ERROR_SLEEP_MILLIS);
             }
 
@@ -936,16 +929,20 @@ public class GerritRestPoller extends Thread implements GerritEventSource, Conne
      * Marks the connection as established and notifies listeners.
      */
     private void notifyConnectionEstablished() {
-        connected = true;
-        notifyListeners(GerritConnectionEvent.GERRIT_CONNECTION_ESTABLISHED);
+        if (!connected) {
+            connected = true;
+            notifyListeners(GerritConnectionEvent.GERRIT_CONNECTION_ESTABLISHED);
+        }
     }
 
     /**
      * Marks the connection as down and notifies listeners.
      */
     private void notifyConnectionDown() {
-        connected = false;
-        notifyListeners(GerritConnectionEvent.GERRIT_CONNECTION_DOWN);
+        if (connected) {
+            connected = false;
+            notifyListeners(GerritConnectionEvent.GERRIT_CONNECTION_DOWN);
+        }
     }
 
     /**

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPoller.java
@@ -1,0 +1,734 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2026 Amarula Solutions All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.tools.gerrit.gerritevents;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import net.sf.json.JSONSerializer;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeKind;
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeStatus;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Account;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.PatchSet;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Provider;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeAbandoned;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeMerged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
+
+/**
+ * Polls the Gerrit REST API over HTTPS to receive change events.
+ *
+ * <p>This is an alternative to {@link GerritConnection}'s SSH-based
+ * {@code stream-events} command. Instead of maintaining a persistent SSH
+ * connection, this class periodically polls the Gerrit REST API to detect
+ * new and updated changes, then posts corresponding events to the
+ * {@link GerritHandler}.</p>
+ *
+ * <p>Detection works by tracking the last-seen revision and status for each
+ * change. When a new change appears or the current revision changes, a
+ * {@link PatchsetCreated} event is emitted. When a change's status changes
+ * (e.g. from NEW to MERGED), the appropriate lifecycle event is emitted.</p>
+ *
+ * @author Michael Trimarchi
+ */
+public class GerritRestPoller extends Thread implements GerritEventSource, Connector {
+
+    private static final Logger logger = LoggerFactory.getLogger(GerritRestPoller.class);
+
+    /**
+     * The scheme name used for HTTPS polling.
+     */
+    public static final String GERRIT_PROTOCOL_SCHEME_NAME = "https";
+
+    /**
+     * Gerrit REST API responses are prefixed with this to prevent JSON hijacking.
+     */
+    private static final String GERRIT_REST_PREFIX = ")]}'";
+
+    /**
+     * Time to wait between connection/poll attempts when in error state.
+     */
+    private static final int ERROR_SLEEP_MILLIS = 5000;
+
+    /**
+     * Time to wait after a successful poll with no changes found.
+     * This is in addition to the configured poll interval.
+     */
+    private static final int IDLE_SLEEP_MILLIS = 500;
+
+    /**
+     * Multiplier for converting seconds to milliseconds.
+     */
+    private static final long MILLIS_PER_SECOND = 1000L;
+
+    private final String gerritName;
+    private final GerritConnectionConfig2 config;
+    private final String frontEndUrl;
+    private final int pollIntervalSeconds;
+    private final int maxChangesPerPoll;
+    private GerritHandler handler;
+    private volatile boolean shutdownInProgress;
+    private volatile boolean connected;
+    private String gerritVersion;
+    private final Set<ConnectionListener> listeners = new CopyOnWriteArraySet<ConnectionListener>();
+    private HttpClient httpClient;
+
+    /**
+     * Tracks the last known state of each change.
+     * Key: changeId, Value: {revision, status}
+     */
+    private final Map<String, ChangeState> knownChanges = new ConcurrentHashMap<String, ChangeState>();
+
+    /**
+     * Stores the last known revision and status for a change.
+     */
+    /**
+     * Stores the last known revision and status for a change.
+     */
+    private static class ChangeState {
+        /** The last known revision. */
+        final String revision;
+        /** The last known status. */
+        final GerritChangeStatus status;
+
+        /**
+         * Creates a new ChangeState.
+         * @param revision the revision.
+         * @param status the status.
+         */
+        ChangeState(String revision, GerritChangeStatus status) {
+            this.revision = revision;
+            this.status = status;
+        }
+    }
+
+    /**
+     * Creates a GerritRestPoller.
+     *
+     * @param gerritName the name of the Gerrit server.
+     * @param config the configuration containing connection and REST values.
+     */
+    public GerritRestPoller(String gerritName, GerritConnectionConfig2 config) {
+        this.gerritName = gerritName;
+        this.config = config;
+        this.frontEndUrl = config.getGerritFrontEndUrl();
+        this.pollIntervalSeconds = config.getHttpsPollInterval();
+        this.maxChangesPerPoll = config.getHttpsPollMaxChanges();
+        logger.info("{}: GerritRestPoller created with poll interval {}s, max changes {}",
+                gerritName, pollIntervalSeconds, maxChangesPerPoll);
+    }
+
+    // ---- GerritEventSource implementation ----
+
+    @Override
+    public void setHandler(GerritHandler handler) {
+        this.handler = handler;
+    }
+
+    @Override
+    public GerritHandler getHandler() {
+        return handler;
+    }
+
+    @Override
+    public void addListener(ConnectionListener listener) {
+        if (!listeners.add(listener)) {
+            logger.warn("{}: Connection listener doubly-added: {}", gerritName, listener);
+        }
+    }
+
+    @Override
+    public void removeListener(ConnectionListener listener) {
+        listeners.remove(listener);
+    }
+
+    @Override
+    public boolean isConnected() {
+        return connected;
+    }
+
+    @Override
+    public String getGerritVersion() {
+        return gerritVersion;
+    }
+
+    @Override
+    public void shutdown(boolean join) {
+        shutdownInProgress = true;
+        if (join) {
+            try {
+                this.join();
+            } catch (InterruptedException ex) {
+                logger.warn("{}: Interrupted while waiting for shutdown.", gerritName, ex);
+            }
+        }
+    }
+
+    // ---- Connector implementation ----
+
+    @Override
+    public void reconnect() {
+        logger.info("{}: Reconnect requested; resetting known changes cache.", gerritName);
+        knownChanges.clear();
+    }
+
+    // ---- Thread main loop ----
+
+    @Override
+    public void run() {
+        logger.info("{}: Starting GerritRestPoller.", gerritName);
+
+        // Perform an initial connection check immediately so that
+        // server health reporting (doWakeup) detects connectivity
+        // without waiting for the first full poll cycle.
+        performInitialConnection();
+
+        while (!shutdownInProgress) {
+            try {
+                // Fetch and detect Gerrit version on first successful request
+                if (gerritVersion == null) {
+                    gerritVersion = fetchGerritVersion();
+                    if (gerritVersion != null) {
+                        logger.info("{}: Detected Gerrit version: {}", gerritName, gerritVersion);
+                    }
+                }
+
+                pollChanges();
+
+                if (!connected) {
+                    notifyConnectionEstablished();
+                }
+            } catch (IOException ex) {
+                logger.error("{}: Error during HTTPS poll: {}", gerritName, ex.getMessage());
+                if (connected) {
+                    notifyConnectionDown();
+                }
+                sleepMillis(ERROR_SLEEP_MILLIS);
+            } catch (Exception ex) {
+                logger.error("{}: Unexpected error during poll.", gerritName, ex);
+                if (connected) {
+                    notifyConnectionDown();
+                }
+                sleepMillis(ERROR_SLEEP_MILLIS);
+            }
+
+            if (!shutdownInProgress) {
+                sleepMillis(pollIntervalSeconds * MILLIS_PER_SECOND);
+            }
+        }
+        if (connected) {
+            notifyConnectionDown();
+        }
+        handler = null;
+        httpClient = null;
+        logger.debug("{}: End of GerritRestPoller Thread.", gerritName);
+    }
+
+    /**
+     * Performs an initial connectivity check to the Gerrit server.
+     * Fetches the server version via a lightweight REST API call.
+     * If successful, notifies connection listeners immediately so that
+     * {@code doWakeup()} detects the server as reachable without waiting
+     * for the first full polling cycle to complete.
+     */
+    private void performInitialConnection() {
+        try {
+            if (httpClient == null) {
+                httpClient = createHttpClient();
+            }
+            if (gerritVersion == null) {
+                gerritVersion = fetchGerritVersion();
+                if (gerritVersion != null) {
+                    logger.info("{}: Detected Gerrit version: {}", gerritName, gerritVersion);
+                }
+            }
+            // Connectivity check succeeded — notify immediately
+            notifyConnectionEstablished();
+        } catch (Exception ex) {
+            logger.warn("{}: Initial connection check failed, will retry in polling loop: {}",
+                    gerritName, ex.getMessage());
+        }
+    }
+
+    // ---- HTTP helpers ----
+
+    /**
+     * Creates an HttpClient configured with the credentials from the config.
+     *
+     * @return a configured HttpClient.
+     */
+    private HttpClient createHttpClient() {
+        Credentials creds = config.getHttpCredentials();
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        credsProvider.setCredentials(AuthScope.ANY, creds);
+        return HttpClients.custom()
+                .setDefaultCredentialsProvider(credsProvider)
+                .build();
+    }
+
+    /**
+     * Executes an HTTP GET request to the Gerrit REST API and returns the
+     * response body as a string.
+     *
+     * @param path the REST API path relative to the front-end URL (e.g. "a/changes/").
+     * @return the response body.
+     * @throws IOException if the request fails.
+     */
+    private String httpGet(String path) throws IOException {
+        String url = frontEndUrl + path;
+        logger.trace("{}: GET {}", gerritName, url);
+        HttpGet httpGet = new HttpGet(url);
+        HttpResponse response = httpClient.execute(httpGet);
+        int statusCode = response.getStatusLine().getStatusCode();
+        if (statusCode != HttpURLConnection.HTTP_OK) {
+            throw new IOException("HTTP " + statusCode + " for " + url);
+        }
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line);
+            }
+        }
+        String body = sb.toString();
+        // Strip Gerrit's JSON hijacking prevention prefix
+        if (body.startsWith(GERRIT_REST_PREFIX)) {
+            body = body.substring(GERRIT_REST_PREFIX.length());
+        }
+        return body;
+    }
+
+    // ---- Gerrit API methods ----
+
+    /**
+     * Fetches the Gerrit server version via the REST API.
+     *
+     * @return the version string, or null if it could not be determined.
+     */
+    private String fetchGerritVersion() {
+        try {
+            String body = httpGet("a/config/server/version");
+            return body.replaceAll("^\"|\"$", "").trim();
+        } catch (IOException ex) {
+            logger.warn("{}: Could not fetch Gerrit version: {}", gerritName, ex.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Polls the Gerrit REST API for open changes and processes any new or
+     * updated changes.
+     *
+     * @throws IOException if a network error occurs.
+     */
+    private void pollChanges() throws IOException {
+        String queryPath = "a/changes/?q=is:open&n=" + maxChangesPerPoll
+                + "&o=CURRENT_REVISION&o=DETAILED_ACCOUNTS&o=CURRENT_COMMIT";
+        String body = httpGet(queryPath);
+        JSONArray changes;
+        try {
+            changes = (JSONArray)JSONSerializer.toJSON(body);
+        } catch (Exception ex) {
+            logger.error("{}: Failed to parse REST API response.", gerritName, ex);
+            return;
+        }
+
+        if (changes == null || changes.isEmpty()) {
+            logger.trace("{}: No open changes found.", gerritName);
+            sleepMillis(IDLE_SLEEP_MILLIS);
+            return;
+        }
+
+        logger.debug("{}: Processing {} open changes.", gerritName, changes.size());
+        Provider provider = createProvider();
+
+        for (int i = 0; i < changes.size(); i++) {
+            if (shutdownInProgress || interrupted()) {
+                return;
+            }
+            try {
+                JSONObject changeJson = changes.getJSONObject(i);
+                processChange(changeJson, provider);
+            } catch (Exception ex) {
+                logger.warn("{}: Error processing change at index {}: {}",
+                        gerritName, i, ex.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Processes a single change from the REST API response and emits
+     * appropriate events if the change is new or has been updated.
+     *
+     * @param changeJson the JSON object representing the change.
+     * @param provider the Provider to attach to events.
+     */
+    private void processChange(JSONObject changeJson, Provider provider) {
+        String changeId = changeJson.getString("id");
+        String project = changeJson.getString("project");
+        String branch = changeJson.optString("branch", "");
+        String subject = changeJson.optString("subject", "");
+        String changeNumber = String.valueOf(changeJson.optInt("_number", -1));
+        String status = changeJson.optString("status", "NEW");
+        GerritChangeStatus changeStatus = GerritChangeStatus.fromString(status);
+
+        // Determine current revision
+        String currentRevision = null;
+        JSONObject currentRevObj = null;
+        if (changeJson.has("current_revision")) {
+            currentRevision = changeJson.getString("current_revision");
+        }
+        if (currentRevision != null && changeJson.has("revisions")) {
+            JSONObject revisions = changeJson.getJSONObject("revisions");
+            if (revisions.has(currentRevision)) {
+                currentRevObj = revisions.getJSONObject(currentRevision);
+            }
+        }
+
+        if (currentRevision == null) {
+            logger.debug("{}: Change {} has no current_revision, skipping.", gerritName, changeId);
+            return;
+        }
+
+        ChangeState previous = knownChanges.get(changeId);
+
+        // Check if this is a new change or the revision has changed
+        boolean isNew = (previous == null);
+        boolean revisionChanged = (previous != null && !currentRevision.equals(previous.revision));
+
+        if (isNew || revisionChanged) {
+            // Build Change and PatchSet DTOs
+            Change change = buildChange(changeJson, changeId, project, branch, subject,
+                    changeNumber, changeStatus);
+            PatchSet patchSet = buildPatchSet(currentRevObj, currentRevision);
+
+            // Build PatchsetCreated event
+            PatchsetCreated event = new PatchsetCreated();
+            event.setChange(change);
+            event.setPatchset(patchSet);
+            event.setProvider(provider);
+            event.setReceivedOn(System.currentTimeMillis());
+
+            // Set the account from owner
+            if (changeJson.has("owner")) {
+                try {
+                    event.setAccount(new Account(changeJson.getJSONObject("owner")));
+                } catch (Exception ex) {
+                    logger.trace("{}: Could not parse owner for change {}: {}",
+                            gerritName, changeId, ex.getMessage());
+                }
+            }
+
+            if (handler != null) {
+                handler.post(event);
+                //CS IGNORE AvoidInlineConditionals FOR NEXT 1 LINES. REASON: Readable ternary.
+                String changeType = isNew ? "(new)" : "(updated)";
+                logger.info("{}: Posted PatchsetCreated for change {}/{} rev {} {}",
+                        gerritName, project, changeNumber, currentRevision, changeType);
+            }
+        }
+
+        // Check for status transitions on known changes
+        if (previous != null && previous.status != changeStatus) {
+            GerritTriggeredEvent statusEvent = null;
+            switch (changeStatus) {
+                case MERGED:
+                    statusEvent = buildStatusEvent(changeJson, project, branch, subject,
+                            changeNumber, currentRevision, currentRevObj, provider,
+                            ChangeMerged.class);
+                    break;
+                case ABANDONED:
+                    statusEvent = buildStatusEvent(changeJson, project, branch, subject,
+                            changeNumber, currentRevision, currentRevObj, provider,
+                            ChangeAbandoned.class);
+                    break;
+                default:
+                    // RESTORED status is not directly distinguishable from NEW
+                    // in all Gerrit versions; handle explicitly if needed
+                    break;
+            }
+            if (statusEvent != null && handler != null) {
+                handler.post(statusEvent);
+                logger.info("{}: Posted status transition for change {}/{}: {} -> {}",
+                        gerritName, project, changeNumber, previous.status, changeStatus);
+            }
+        }
+
+        // Update known state
+        knownChanges.put(changeId, new ChangeState(currentRevision, changeStatus));
+    }
+
+    /**
+     * Builds a Change DTO from the REST API JSON.
+     * @param changeJson the JSON object for this change.
+     * @param changeId the change ID.
+     * @param project the project name.
+     * @param branch the branch name.
+     * @param subject the change subject.
+     * @param changeNumber the change number.
+     * @param status the change status.
+     * @return a new Change DTO.
+     */
+    private Change buildChange(JSONObject changeJson, String changeId, String project,
+            String branch, String subject, String changeNumber, GerritChangeStatus status) {
+        Change change = new Change();
+        change.setProject(project);
+        change.setBranch(branch);
+        change.setId(changeId);
+        change.setNumber(changeNumber);
+        change.setSubject(subject);
+        change.setStatus(status);
+        if (changeJson.has("owner")) {
+            try {
+                change.setOwner(new Account(changeJson.getJSONObject("owner")));
+            } catch (Exception ex) {
+                logger.trace("Could not set owner on change: {}", ex.getMessage());
+            }
+        }
+        // Set URL
+        String url = frontEndUrl + changeNumber;
+        change.setUrl(url);
+        return change;
+    }
+
+    /**
+     * Builds a PatchSet DTO from the revision JSON.
+     * @param revisionObj the JSON object for this revision, or null.
+     * @param revision the revision SHA.
+     * @return a new PatchSet DTO.
+     */
+    private PatchSet buildPatchSet(JSONObject revisionObj, String revision) {
+        PatchSet patchSet = new PatchSet();
+        patchSet.setRevision(revision);
+        if (revisionObj != null) {
+            String patchNumber = String.valueOf(revisionObj.optInt("_number", 1));
+            patchSet.setNumber(patchNumber);
+            String ref = revisionObj.optString("ref", "");
+            patchSet.setRef(ref);
+            if (revisionObj.has("uploader")) {
+                try {
+                    patchSet.setUploader(new Account(revisionObj.getJSONObject("uploader")));
+                } catch (Exception ex) {
+                    logger.trace("Could not set uploader on patchset: {}", ex.getMessage());
+                }
+            }
+            if (revisionObj.has("kind")) {
+                patchSet.setKind(GerritChangeKind.fromString(revisionObj.getString("kind")));
+            }
+            if (revisionObj.has("created")) {
+                String createdStr = revisionObj.getString("created");
+                patchSet.setCreatedOn(parseGerritDate(createdStr));
+            }
+        } else {
+            patchSet.setNumber("1");
+        }
+        return patchSet;
+    }
+
+    /**
+     * Builds a status transition event (ChangeMerged, ChangeAbandoned, etc.).
+     * @param changeJson the JSON object for the change.
+     * @param project the project name.
+     * @param branch the branch name.
+     * @param subject the change subject.
+     * @param changeNumber the change number.
+     * @param revision the current revision SHA.
+     * @param revisionObj the JSON object for the revision.
+     * @param provider the Provider to attach.
+     * @param eventClass the event class to build (ChangeMerged.class or ChangeAbandoned.class).
+     * @return a new GerritTriggeredEvent, or null on failure.
+     */
+    private GerritTriggeredEvent buildStatusEvent(JSONObject changeJson, String project,
+            String branch, String subject, String changeNumber, String revision,
+            JSONObject revisionObj, Provider provider, Class<?> eventClass) {
+        try {
+            Change change = buildChange(changeJson, changeJson.getString("id"), project, branch,
+                    subject, changeNumber, GerritChangeStatus.fromString(
+                            changeJson.optString("status", "")));
+            PatchSet patchSet = buildPatchSet(revisionObj, revision);
+
+            if (eventClass == ChangeMerged.class) {
+                ChangeMerged event = new ChangeMerged();
+                event.setChange(change);
+                event.setPatchset(patchSet);
+                event.setProvider(provider);
+                event.setReceivedOn(System.currentTimeMillis());
+                if (changeJson.has("owner")) {
+                    event.setAccount(new Account(changeJson.getJSONObject("owner")));
+                }
+                return event;
+            } else if (eventClass == ChangeAbandoned.class) {
+                ChangeAbandoned event = new ChangeAbandoned();
+                event.setChange(change);
+                event.setPatchset(patchSet);
+                event.setProvider(provider);
+                event.setReceivedOn(System.currentTimeMillis());
+                if (changeJson.has("owner")) {
+                    event.setAccount(new Account(changeJson.getJSONObject("owner")));
+                }
+                // Set abandoner if available
+                if (changeJson.has("abandoner")) {
+                    // Store abandoner as the account field for ChangeAbandoned
+                    event.setAbandoner(new Account(changeJson.getJSONObject("abandoner")));
+                }
+                return event;
+            }
+        } catch (Exception ex) {
+            logger.warn("{}: Failed to build status event: {}", gerritName, ex.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Creates a Provider for the current connection.
+     * @return a new Provider.
+     */
+    private Provider createProvider() {
+        //CS IGNORE AvoidInlineConditionals FOR NEXT 1 LINES. REASON: Readable null check.
+        String version = gerritVersion != null ? gerritVersion : "";
+        return new Provider(
+                gerritName,
+                config.getGerritHostName(),
+                String.valueOf(config.getGerritSshPort()),
+                GERRIT_PROTOCOL_SCHEME_NAME,
+                frontEndUrl,
+                version);
+    }
+
+    // ---- Date parsing ----
+
+    /**
+     * Parses a Gerrit REST API date string.
+     * Gerrit uses formats like "2023-01-15 10:00:00.000000000" or
+     * "2023-01-15 10:00:00".
+     *
+     * @param dateStr the date string.
+     * @return a Date, or null if parsing fails.
+     */
+    static Date parseGerritDate(String dateStr) {
+        if (dateStr == null || dateStr.isEmpty()) {
+            return null;
+        }
+        try {
+            // Strip nanoseconds if present (Gerrit uses 9 digits after dot)
+            String normalized = dateStr.replace(" ", "T");
+            int dotIndex = normalized.indexOf('.');
+            if (dotIndex >= 0) {
+                normalized = normalized.substring(0, dotIndex);
+            }
+            return new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(normalized);
+        } catch (Exception ex) {
+            logger.trace("Could not parse date: {}", dateStr, ex);
+            return null;
+        }
+    }
+
+    // ---- Notification helpers ----
+
+    /**
+     * Marks the connection as established and notifies listeners.
+     */
+    private void notifyConnectionEstablished() {
+        connected = true;
+        notifyListeners(GerritConnectionEvent.GERRIT_CONNECTION_ESTABLISHED);
+    }
+
+    /**
+     * Marks the connection as down and notifies listeners.
+     */
+    private void notifyConnectionDown() {
+        connected = false;
+        notifyListeners(GerritConnectionEvent.GERRIT_CONNECTION_DOWN);
+    }
+
+    /**
+     * Notifies all registered connection listeners of an event.
+     * @param event the connection event.
+     */
+    private void notifyListeners(GerritConnectionEvent event) {
+        for (ConnectionListener listener : listeners) {
+            try {
+                switch (event) {
+                    case GERRIT_CONNECTION_ESTABLISHED:
+                        listener.connectionEstablished();
+                        break;
+                    case GERRIT_CONNECTION_DOWN:
+                        listener.connectionDown();
+                        break;
+                    default:
+                        break;
+                }
+            } catch (Exception ex) {
+                logger.error("{}: ConnectionListener threw Exception.", gerritName, ex);
+            }
+        }
+    }
+
+    /**
+     * Sleeps for the specified number of milliseconds, handling interrupts.
+     * @param millis the number of milliseconds to sleep.
+     */
+    private void sleepMillis(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ex) {
+            logger.trace("{}: Sleep interrupted.", gerritName);
+        }
+    }
+
+    /**
+     * Returns an unmodifiable view of the set of {@link ConnectionListener}s.
+     *
+     * @return the set of connection listeners.
+     */
+    public Set<ConnectionListener> getListenersView() {
+        return Collections.unmodifiableSet(listeners);
+    }
+}

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestQueryHandler.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestQueryHandler.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
@@ -37,6 +39,7 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
 
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
@@ -44,6 +47,7 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,6 +76,7 @@ public class GerritRestQueryHandler extends GerritQueryHandler {
 
     private final String frontEndUrl;
     private final Credentials httpCredentials;
+    private final String proxy;
     private HttpClient httpClient;
 
     /**
@@ -89,6 +94,7 @@ public class GerritRestQueryHandler extends GerritQueryHandler {
               GerritDefaultValues.DEFAULT_GERRIT_SSH_CONNECTION_TIMEOUT);
         this.frontEndUrl = config.getGerritFrontEndUrl();
         this.httpCredentials = config.getHttpCredentials();
+        this.proxy = config.getGerritProxy();
     }
 
     /**
@@ -107,6 +113,7 @@ public class GerritRestQueryHandler extends GerritQueryHandler {
         super(hostName, sshPort, proxy, auth);
         this.frontEndUrl = frontEndUrl;
         this.httpCredentials = httpCredentials;
+        this.proxy = proxy;
     }
 
     // ---- Override the master queryJava method (6-param) ----
@@ -454,9 +461,18 @@ public class GerritRestQueryHandler extends GerritQueryHandler {
         if (httpClient == null) {
             CredentialsProvider credsProvider = new BasicCredentialsProvider();
             credsProvider.setCredentials(AuthScope.ANY, httpCredentials);
-            httpClient = HttpClients.custom()
-                    .setDefaultCredentialsProvider(credsProvider)
-                    .build();
+            HttpClientBuilder builder = HttpClients.custom()
+                    .setDefaultCredentialsProvider(credsProvider);
+            if (proxy != null && !proxy.isEmpty()) {
+                try {
+                    URL url = new URL(proxy);
+                    builder.setProxy(new HttpHost(url.getHost(), url.getPort(), url.getProtocol()));
+                } catch (MalformedURLException e) {
+                    logger.warn("Could not parse HTTP proxy URL, proceeding without proxy: {}",
+                            e.getMessage());
+                }
+            }
+            httpClient = builder.build();
         }
         return httpClient;
     }

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestQueryHandler.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestQueryHandler.java
@@ -1,0 +1,478 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2026 Amarula Solutions All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.tools.gerrit.gerritevents;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedList;
+import java.util.List;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+import net.sf.json.JSONSerializer;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Executes Gerrit queries via the REST API instead of SSH.
+ *
+ * <p>Extends {@link GerritQueryHandler} and overrides the query methods to use
+ * HTTP GET requests against the Gerrit REST API {@code /a/changes/} endpoint.
+ * REST API responses are converted to the same JSON format that the SSH
+ * {@code gerrit query} command produces, so existing callers like
+ * {@code FileHelper} and {@code Topic} work unchanged.</p>
+ *
+ * @author Michael Trimarchi
+ */
+public class GerritRestQueryHandler extends GerritQueryHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(GerritRestQueryHandler.class);
+
+    private static final String GERRIT_REST_PREFIX = ")]}'";
+    private static final int DEFAULT_MAX_RESULTS = 500;
+    /**
+     * Divisor for converting milliseconds to seconds.
+     */
+    private static final long MILLIS_PER_SECOND = 1000L;
+
+    private final String frontEndUrl;
+    private final Credentials httpCredentials;
+    private HttpClient httpClient;
+
+    /**
+     * Creates a GerritRestQueryHandler from the given configuration.
+     * The SSH-specific parameters from the config are passed to the superclass
+     * constructor but are not used by this REST-based implementation.
+     *
+     * @param config the configuration containing REST API connection values.
+     */
+    public GerritRestQueryHandler(GerritConnectionConfig2 config) {
+        super(config.getGerritHostName(),
+              config.getGerritSshPort(),
+              config.getGerritProxy(),
+              config.getGerritAuthentication(),
+              GerritDefaultValues.DEFAULT_GERRIT_SSH_CONNECTION_TIMEOUT);
+        this.frontEndUrl = config.getGerritFrontEndUrl();
+        this.httpCredentials = config.getHttpCredentials();
+    }
+
+    /**
+     * Creates a GerritRestQueryHandler with explicit parameters.
+     *
+     * @param frontEndUrl the Gerrit front-end URL.
+     * @param httpCredentials the HTTP credentials.
+     * @param hostName the host name (for superclass, unused).
+     * @param sshPort the SSH port (for superclass, unused).
+     * @param proxy the proxy (for superclass, unused).
+     * @param auth the SSH authentication (for superclass, unused).
+     */
+    public GerritRestQueryHandler(String frontEndUrl, Credentials httpCredentials,
+            String hostName, int sshPort, String proxy,
+            com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication auth) {
+        super(hostName, sshPort, proxy, auth);
+        this.frontEndUrl = frontEndUrl;
+        this.httpCredentials = httpCredentials;
+    }
+
+    // ---- Override the master queryJava method (6-param) ----
+
+    @Override
+    public List<JSONObject> queryJava(String queryString, boolean getPatchSets,
+            boolean getCurrentPatchSet, boolean getFiles, boolean getCommitMessage,
+            boolean getComments) throws IOException, GerritQueryException {
+        String jsonResponse = executeRestQuery(queryString, getPatchSets,
+                getCurrentPatchSet, getFiles, getCommitMessage, getComments);
+        JSONArray changes;
+        try {
+            changes = (JSONArray)JSONSerializer.toJSON(jsonResponse);
+        } catch (Exception ex) {
+            throw new GerritQueryException("Failed to parse REST API response", ex);
+        }
+        return convertToQueryFormat(changes);
+    }
+
+    // ---- Override the master queryJson method (5-param) ----
+
+    @Override
+    public List<String> queryJson(String queryString, boolean getPatchSets,
+            boolean getCurrentPatchSet, boolean getFiles, boolean getCommitMessage)
+            throws IOException {
+        List<String> list = new LinkedList<String>();
+        try {
+            List<JSONObject> objects = queryJava(queryString, getPatchSets,
+                    getCurrentPatchSet, getFiles, getCommitMessage, false);
+            for (JSONObject obj : objects) {
+                list.add(obj.toString());
+            }
+        } catch (GerritQueryException gqe) {
+            logger.error("This should not have happened!", gqe);
+        }
+        return list;
+    }
+
+    // ---- REST API execution ----
+
+    /**
+     * Executes a query against the Gerrit REST API.
+     *
+     * @param queryString the Gerrit query string.
+     * @param getPatchSets if true, include all revisions.
+     * @param getCurrentPatchSet if true, include the current revision.
+     * @param getFiles if true, include changed files.
+     * @param getCommitMessage if true, include the full commit message.
+     * @param getComments if true, include inline comments.
+     * @return the raw JSON response body.
+     * @throws IOException if a network error occurs.
+     */
+    private String executeRestQuery(String queryString, boolean getPatchSets,
+            boolean getCurrentPatchSet, boolean getFiles, boolean getCommitMessage,
+            boolean getComments) throws IOException {
+        StringBuilder urlBuilder = new StringBuilder(frontEndUrl);
+        if (!frontEndUrl.endsWith("/")) {
+            urlBuilder.append('/');
+        }
+        urlBuilder.append("a/changes/?q=");
+        urlBuilder.append(urlEncode(queryString));
+        urlBuilder.append("&n=").append(DEFAULT_MAX_RESULTS);
+
+        // Always request detailed accounts and labels so that owner/uploader
+        // contain 'name', 'email', and 'username', and labels/approvals
+        // (Verified, Code-Review) are available for the manual trigger page.
+        urlBuilder.append("&o=DETAILED_ACCOUNTS");
+        urlBuilder.append("&o=LABELS");
+
+        // Map SSH query flags to REST API options
+        if (getPatchSets) {
+            urlBuilder.append("&o=ALL_REVISIONS");
+        }
+        if (getCurrentPatchSet) {
+            urlBuilder.append("&o=CURRENT_REVISION");
+        }
+        if (getFiles) {
+            urlBuilder.append("&o=CURRENT_FILES");
+        }
+        if (getCommitMessage) {
+            urlBuilder.append("&o=CURRENT_COMMIT");
+        }
+        if (getComments) {
+            urlBuilder.append("&o=MESSAGES");
+        }
+
+        String url = urlBuilder.toString();
+        logger.trace("REST query: {}", url);
+
+        HttpClient client = getHttpClient();
+        HttpGet httpGet = new HttpGet(url);
+        HttpResponse response = client.execute(httpGet);
+        int statusCode = response.getStatusLine().getStatusCode();
+        if (statusCode != HttpURLConnection.HTTP_OK) {
+            throw new IOException("HTTP " + statusCode + " for query: " + url);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(response.getEntity().getContent(),
+                        StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line);
+            }
+        }
+        String body = sb.toString();
+        if (body.startsWith(GERRIT_REST_PREFIX)) {
+            body = body.substring(GERRIT_REST_PREFIX.length());
+        }
+        return body;
+    }
+
+    /**
+     * Converts a REST API JSON array of changes into the SSH query JSON format.
+     *
+     * @param changes the JSON array from {@code GET /a/changes/}.
+     * @return a list of JSONObjects in the SSH query format.
+     */
+    private List<JSONObject> convertToQueryFormat(JSONArray changes) {
+        List<JSONObject> result = new LinkedList<JSONObject>();
+        for (int i = 0; i < changes.size(); i++) {
+            JSONObject restChange = changes.getJSONObject(i);
+            JSONObject queryJson = convertSingleChange(restChange);
+            if (queryJson != null) {
+                result.add(queryJson);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Converts a single REST API change JSON to SSH query format.
+     *
+     * @param rest the change JSON from the REST API.
+     * @return a JSONObject in SSH query format, or null if conversion fails.
+     */
+    private JSONObject convertSingleChange(JSONObject rest) {
+        JSONObject q = new JSONObject();
+
+        // Top-level fields — map REST names to SSH query names
+        q.put("project", rest.optString("project", ""));
+        q.put("branch", rest.optString("branch", ""));
+        // use change_id (e.g. Iabc123...) not id (p~master~Iabc123...)
+        if (rest.has("change_id")) {
+            q.put("id", rest.getString("change_id"));
+        } else {
+            q.put("id", rest.optString("id", ""));
+        }
+        // _number is an integer in REST, but SSH query uses string
+        if (rest.has("_number")) {
+            q.put("number", String.valueOf(rest.getInt("_number")));
+        } else {
+            q.put("number", rest.optString("number", ""));
+        }
+        q.put("subject", rest.optString("subject", ""));
+        q.put("status", rest.optString("status", "NEW"));
+        q.put("open", "NEW".equals(rest.optString("status", "NEW")));
+
+        // Owner — accounts from REST include _account_id which Account.fromJson ignores
+        if (rest.has("owner")) {
+            q.put("owner", rest.getJSONObject("owner"));
+        }
+
+        // URL — constructed from frontEndUrl + change number
+        String changeNumber = String.valueOf(rest.optInt("_number", -1));
+        q.put("url", frontEndUrl + changeNumber);
+
+        // Convert timestamps from ISO-8601 to epoch seconds
+        if (rest.has("created")) {
+            q.put("createdOn", convertToEpochSeconds(rest.optString("created", "")));
+        }
+        if (rest.has("updated")) {
+            q.put("lastUpdated", convertToEpochSeconds(rest.optString("updated", "")));
+        }
+
+        // Commit message from the revisions[cr].commit.message
+        String currentRev = rest.optString("current_revision", null);
+        JSONObject revisions = rest.optJSONObject("revisions");
+        JSONObject revObj = null;
+        if (currentRev != null && revisions != null && revisions.has(currentRev)) {
+            revObj = revisions.getJSONObject(currentRev);
+        }
+
+        if (revObj != null && revObj.has("commit")) {
+            JSONObject commit = revObj.getJSONObject("commit");
+            if (commit.has("message")) {
+                q.put("commitMessage", commit.getString("message"));
+            }
+        }
+
+        // Build currentPatchSet object
+        if (revObj != null) {
+            JSONObject patchSet = new JSONObject();
+            if (revObj.has("_number")) {
+                patchSet.put("number", String.valueOf(revObj.getInt("_number")));
+            } else {
+                patchSet.put("number", "1");
+            }
+            patchSet.put("revision", currentRev);
+            patchSet.put("ref", revObj.optString("ref", ""));
+            if (revObj.has("kind")) {
+                patchSet.put("kind", revObj.getString("kind"));
+            }
+            if (revObj.has("created")) {
+                patchSet.put("createdOn", convertToEpochSeconds(revObj.optString("created", "")));
+            }
+            if (revObj.has("uploader")) {
+                patchSet.put("uploader", revObj.getJSONObject("uploader"));
+            }
+
+            // Convert REST labels map to SSH approvals array
+            JSONObject labels = revObj.optJSONObject("labels");
+            if (labels == null) {
+                labels = rest.optJSONObject("labels");
+            }
+            if (labels != null) {
+                patchSet.put("approvals", convertLabelsToApprovals(labels));
+            }
+
+            // Convert files from REST map format to array format
+            if (revObj.has("files")) {
+                JSONObject restFiles = revObj.optJSONObject("files");
+                JSONArray fileArray = new JSONArray();
+                if (restFiles != null) {
+                    for (Object key : restFiles.keySet()) {
+                        String fileName = (String)key;
+                        JSONObject restFile = restFiles.getJSONObject(fileName);
+                        JSONObject fileObj = new JSONObject();
+                        fileObj.put("file", fileName);
+                        if (restFile.has("lines_inserted")) {
+                            fileObj.put("linesInserted", restFile.getInt("lines_inserted"));
+                        }
+                        if (restFile.has("lines_deleted")) {
+                            fileObj.put("linesDeleted", restFile.getInt("lines_deleted"));
+                        }
+                        fileArray.add(fileObj);
+                    }
+                }
+                patchSet.put("files", fileArray);
+            }
+
+            q.put("currentPatchSet", patchSet);
+        }
+
+        // All patchsets (ALL_REVISIONS) — convert to patchSets array
+        if (revisions != null && rest.has("o") && rest.getString("o").contains("ALL_REVISIONS")) {
+            // We only construct patchSets if ALL_REVISIONS was actually requested;
+            // the REST API doesn't have a direct flag we can check in the response.
+            // We check if there are multiple revisions.
+            JSONArray patchSetsArr = new JSONArray();
+            for (Object rKey : revisions.keySet()) {
+                String rRev = (String)rKey;
+                JSONObject rObj = revisions.getJSONObject(rRev);
+                JSONObject ps = new JSONObject();
+                ps.put("revision", rRev);
+                if (rObj.has("_number")) {
+                    ps.put("number", String.valueOf(rObj.getInt("_number")));
+                }
+                ps.put("ref", rObj.optString("ref", ""));
+                if (rObj.has("kind")) {
+                    ps.put("kind", rObj.getString("kind"));
+                }
+                if (rObj.has("uploader")) {
+                    ps.put("uploader", rObj.getJSONObject("uploader"));
+                }
+                JSONObject revLabels = rObj.optJSONObject("labels");
+                if (revLabels != null) {
+                    ps.put("approvals", convertLabelsToApprovals(revLabels));
+                }
+                patchSetsArr.add(ps);
+            }
+            q.put("patchSets", patchSetsArr);
+        }
+
+        return q;
+    }
+
+    /**
+     * Converts a Gerrit ISO-8601 date string to epoch seconds.
+     *
+     * @param dateStr the date string, e.g. "2023-01-15 10:00:00.000000000".
+     * @return epoch seconds, or 0 if parsing fails.
+     */
+    private long convertToEpochSeconds(String dateStr) {
+        if (dateStr == null || dateStr.isEmpty()) {
+            return 0;
+        }
+        try {
+            String normalized = dateStr.replace(" ", "T");
+            int dotIndex = normalized.indexOf('.');
+            if (dotIndex >= 0) {
+                normalized = normalized.substring(0, dotIndex);
+            }
+            java.util.Date d = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(normalized);
+            return d.getTime() / MILLIS_PER_SECOND;
+        } catch (Exception ex) {
+            logger.trace("Could not parse date: {}", dateStr, ex);
+            return 0;
+        }
+    }
+
+    /**
+     * Converts a Gerrit REST API labels object to an SSH-format approvals JSONArray.
+     * REST format: {@code {"Code-Review": {"value": 1}, "Verified": {"value": -1}}}
+     * SSH format:  {@code [{"type": "Code-Review", "value": "1"}, ...]}
+     *
+     * @param labels the labels JSONObject from the REST API.
+     * @return a JSONArray of approval objects in SSH format.
+     */
+    private static JSONArray convertLabelsToApprovals(JSONObject labels) {
+        JSONArray approvals = new JSONArray();
+        for (Object key : labels.keySet()) {
+            String labelName = (String)key;
+            JSONObject labelData = labels.getJSONObject(labelName);
+            JSONObject approval = new JSONObject();
+            approval.put("type", labelName);
+            // REST API labels have an 'all' array with the aggregate votes,
+            // e.g. {"all": [{"value": 1, "_account_id": 1000000}, ...]}
+            // Use the first entry as the current approval value.
+            if (labelData.has("all")) {
+                JSONArray allVotes = labelData.getJSONArray("all");
+                if (allVotes.size() > 0) {
+                    approval.put("value",
+                            allVotes.getJSONObject(0).optString("value", "0"));
+                } else {
+                    approval.put("value", "0");
+                }
+            } else if (labelData.has("value")) {
+                approval.put("value", labelData.optString("value", "0"));
+            } else {
+                approval.put("value", "0");
+            }
+            approvals.add(approval);
+        }
+        return approvals;
+    }
+
+    /**
+     * Returns the HTTP client, creating it lazily if necessary.
+     *
+     * @return a configured HttpClient.
+     */
+    private HttpClient getHttpClient() {
+        if (httpClient == null) {
+            CredentialsProvider credsProvider = new BasicCredentialsProvider();
+            credsProvider.setCredentials(AuthScope.ANY, httpCredentials);
+            httpClient = HttpClients.custom()
+                    .setDefaultCredentialsProvider(credsProvider)
+                    .build();
+        }
+        return httpClient;
+    }
+
+    /**
+     * URL-encodes a string using UTF-8.
+     *
+     * @param value the string to encode.
+     * @return the encoded string.
+     */
+    private static String urlEncode(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException ex) {
+            // UTF-8 is always supported
+            return value;
+        }
+    }
+}

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestQueryHandler.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestQueryHandler.java
@@ -28,8 +28,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -40,16 +38,12 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
 
-import org.apache.http.HttpHost;
+import com.sonymobile.tools.gerrit.gerritevents.helpers.HttpClientFactory;
+
 import org.apache.http.HttpResponse;
-import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
-import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -451,20 +445,7 @@ public class GerritRestQueryHandler extends GerritQueryHandler {
      */
     private HttpClient getHttpClient() {
         if (httpClient == null) {
-            CredentialsProvider credsProvider = new BasicCredentialsProvider();
-            credsProvider.setCredentials(AuthScope.ANY, httpCredentials);
-            HttpClientBuilder builder = HttpClients.custom()
-                    .setDefaultCredentialsProvider(credsProvider);
-            if (proxy != null && !proxy.isEmpty()) {
-                try {
-                    URL url = new URL(proxy);
-                    builder.setProxy(new HttpHost(url.getHost(), url.getPort(), url.getProtocol()));
-                } catch (MalformedURLException e) {
-                    logger.warn("Could not parse HTTP proxy URL, proceeding without proxy: {}",
-                            e.getMessage());
-                }
-            }
-            httpClient = builder.build();
+            httpClient = HttpClientFactory.createClient(httpCredentials, proxy);
         }
         return httpClient;
     }

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestQueryHandler.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestQueryHandler.java
@@ -32,6 +32,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -394,26 +395,17 @@ public class GerritRestQueryHandler extends GerritQueryHandler {
 
     /**
      * Converts a Gerrit ISO-8601 date string to epoch seconds.
+     * Delegates to {@link GerritRestPoller#parseGerritDate}.
      *
      * @param dateStr the date string, e.g. "2023-01-15 10:00:00.000000000".
      * @return epoch seconds, or 0 if parsing fails.
      */
     private long convertToEpochSeconds(String dateStr) {
-        if (dateStr == null || dateStr.isEmpty()) {
+        Date d = GerritRestPoller.parseGerritDate(dateStr);
+        if (d == null) {
             return 0;
         }
-        try {
-            String normalized = dateStr.replace(" ", "T");
-            int dotIndex = normalized.indexOf('.');
-            if (dotIndex >= 0) {
-                normalized = normalized.substring(0, dotIndex);
-            }
-            java.util.Date d = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss").parse(normalized);
-            return d.getTime() / MILLIS_PER_SECOND;
-        } catch (Exception ex) {
-            logger.trace("Could not parse date: {}", dateStr, ex);
-            return 0;
-        }
+        return d.toInstant().getEpochSecond();
     }
 
     /**

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/helpers/HttpClientFactory.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/helpers/HttpClientFactory.java
@@ -1,0 +1,63 @@
+package com.sonymobile.tools.gerrit.gerritevents.helpers;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Factory for creating pre-configured {@link HttpClient} instances with
+ * HTTP credentials and optional proxy support.
+ *
+ * <p>Centralises the {@code BasicCredentialsProvider} + proxy construction
+ * that was duplicated across {@code GerritRestQueryHandler},
+ * {@code GerritRestPoller}, {@code AbstractRestCommandJob} and
+ * {@code AbstractRestCommandJob2}.</p>
+ */
+public final class HttpClientFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpClientFactory.class);
+
+    /**
+     * Utility class — no instantiation.
+     */
+    private HttpClientFactory() {
+    }
+
+    /**
+     * Creates an {@link HttpClient} configured with the given credentials
+     * and optional HTTP proxy URL.
+     *
+     * @param credentials the HTTP credentials (may be {@code null}).
+     * @param proxyUrl    the proxy URL, or {@code null}/empty to skip.
+     * @return a configured {@link HttpClient}.
+     */
+    public static HttpClient createClient(Credentials credentials, String proxyUrl) {
+        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        credsProvider.setCredentials(AuthScope.ANY, credentials);
+
+        HttpClientBuilder builder = HttpClients.custom()
+                .setDefaultCredentialsProvider(credsProvider);
+
+        if (proxyUrl != null && !proxyUrl.isEmpty()) {
+            try {
+                URL url = new URL(proxyUrl);
+                builder.setProxy(new HttpHost(url.getHost(), url.getPort(), url.getProtocol()));
+            } catch (MalformedURLException e) {
+                logger.warn("Could not parse HTTP proxy URL, proceeding without proxy: {}",
+                        e.getMessage());
+            }
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/workers/rest/AbstractRestCommandJob.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/workers/rest/AbstractRestCommandJob.java
@@ -28,26 +28,19 @@ import com.google.gson.Gson;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.rest.ChangeId;
 import com.sonymobile.tools.gerrit.gerritevents.dto.rest.ReviewInput;
+import com.sonymobile.tools.gerrit.gerritevents.helpers.HttpClientFactory;
 import com.sonymobile.tools.gerrit.gerritevents.rest.RestConnectionConfig;
 import org.apache.http.HttpStatus;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
 
 /**
  * An abstract Job implementation
@@ -101,26 +94,8 @@ public abstract class AbstractRestCommandJob implements Runnable {
             return;
         }
 
-        CredentialsProvider credsProvider = new BasicCredentialsProvider();
-        credsProvider.setCredentials(new AuthScope(null, -1),
-            config.getHttpCredentials());
-        HttpClientBuilder builder =
-            HttpClients.custom().setDefaultCredentialsProvider(credsProvider);
-        if (config.getGerritProxy() != null && !config.getGerritProxy().isEmpty()) {
-            try {
-                URL url = new URL(config.getGerritProxy());
-                HttpHost proxy = new HttpHost(
-                    url.getHost(), url.getPort(), url.getProtocol());
-                builder.setProxy(proxy);
-            } catch (MalformedURLException e) {
-                logger.error("Could not parse proxy URL, attempting without proxy.", e);
-                if (altLogger != null) {
-                    altLogger.print("ERROR Could not parse proxy URL, attempting without proxy. "
-                            + e.getMessage());
-                }
-            }
-        }
-        HttpClient httpclient = builder.build();
+        HttpClient httpclient = HttpClientFactory.createClient(
+                config.getHttpCredentials(), config.getGerritProxy());
         try {
             HttpResponse httpResponse = httpclient.execute(httpPost);
             String response = IOUtils.toString(httpResponse.getEntity().getContent(), "UTF-8");

--- a/src/main/java/com/sonymobile/tools/gerrit/gerritevents/workers/rest/AbstractRestCommandJob2.java
+++ b/src/main/java/com/sonymobile/tools/gerrit/gerritevents/workers/rest/AbstractRestCommandJob2.java
@@ -27,29 +27,22 @@ import com.google.gson.Gson;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.rest.ChangeId;
 import com.sonymobile.tools.gerrit.gerritevents.dto.rest.ReviewInput;
+import com.sonymobile.tools.gerrit.gerritevents.helpers.HttpClientFactory;
 import com.sonymobile.tools.gerrit.gerritevents.rest.RestConnectionConfig;
 
 import org.apache.http.HttpStatus;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
+import org.apache.http.HttpResponse;
 import org.apache.http.auth.Credentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.concurrent.Callable;
 
 /**
@@ -116,32 +109,10 @@ public abstract class AbstractRestCommandJob2 implements Callable<String> {
             return response;
         }
 
-        CredentialsProvider credProvider = new BasicCredentialsProvider();
-        credProvider.setCredentials(AuthScope.ANY, credentials);
-
-        HttpHost proxy = null;
-        if (httpProxy != null && !httpProxy.isEmpty()) {
-            try {
-                URL url = new URL(httpProxy);
-                proxy = new HttpHost(url.getHost(), url.getPort(), url.getProtocol());
-            } catch (MalformedURLException e) {
-                logger.error("Could not parse proxy URL, attempting without proxy.", e);
-                if (altLogger != null) {
-                    altLogger.print("ERROR Could not parse proxy URL, attempting without proxy. "
-                            + e.getMessage());
-                }
-            }
-        }
-
-        HttpClientBuilder builder = HttpClients.custom();
-        builder.setDefaultCredentialsProvider(credProvider);
-        if (proxy != null) {
-            builder.setProxy(proxy);
-        }
-        CloseableHttpClient httpClient = builder.build();
+        HttpClient httpClient = HttpClientFactory.createClient(credentials, httpProxy);
 
         try {
-            CloseableHttpResponse httpResponse = httpClient.execute(httpPost);
+            HttpResponse httpResponse = httpClient.execute(httpPost);
             response = IOUtils.toString(httpResponse.getEntity().getContent(), "UTF-8");
 
             if (httpResponse.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
@@ -216,6 +216,9 @@ public class GerritRestPollerTest {
         poller = new GerritRestPoller("testServer", config);
         handlerMock = new HandlerMock(null);
         listenerMock = new ListenerMock(null);
+        // Tests exercise processChange() directly; set firstPollDone so
+        // the guard does not skip event emission for every call.
+        org.powermock.reflect.Whitebox.setInternalState(poller, "firstPollDone", true);
     }
 
     /**

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
@@ -43,6 +43,7 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Provider;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PrivateStateChanged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.WipStateChanged;
 import com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication;
 import com.sonymobile.tools.gerrit.gerritevents.watchdog.WatchTimeExceptionData;
@@ -51,7 +52,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-//CS IGNORE MagicNumber FOR NEXT 600 LINES. REASON: TestData
+//CS IGNORE MagicNumber FOR NEXT 700 LINES. REASON: TestData
 
 /**
  * Tests for {@link GerritRestPoller}.
@@ -374,12 +375,26 @@ public class GerritRestPollerTest {
             int changeNumber, String subject, String status, String revision,
             String topic) {
         return buildRestChangeJson(changeId, project, branch, changeNumber, subject, status,
-                revision, topic, false);
+                revision, topic, false, false);
     }
 
+    /**
+     * Builds a REST API JSON change object with WIP and private flag support.
+     * @param changeId the change ID.
+     * @param project the project name.
+     * @param branch the branch name.
+     * @param changeNumber the change number.
+     * @param subject the change subject.
+     * @param status the change status.
+     * @param revision the current revision SHA.
+     * @param topic the topic, or null.
+     * @param wip whether the change is work-in-progress.
+     * @param isPrivate whether the change is private.
+     * @return a JSON object representing a REST API change.
+     */
     private JSONObject buildRestChangeJson(String changeId, String project, String branch,
             int changeNumber, String subject, String status, String revision,
-            String topic, boolean wip) {
+            String topic, boolean wip, boolean isPrivate) {
         JSONObject json = new JSONObject();
         json.put("id", changeId);
         json.put("project", project);
@@ -389,6 +404,7 @@ public class GerritRestPollerTest {
         json.put("status", status);
         json.put("current_revision", revision);
         json.put("work_in_progress", wip);
+        json.put("is_private", isPrivate);
         if (topic != null) {
             json.put("topic", topic);
         }
@@ -544,13 +560,13 @@ public class GerritRestPollerTest {
         String changeId = "proj~master~Iwip1";
 
         JSONObject first = buildRestChangeJson(changeId, "proj", "master", 10,
-                "Test", "NEW", "rev1", null, false);
+                "Test", "NEW", "rev1", null, false, false);
         org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", first, provider);
         assertEquals(1, handlerMock.eventCount);
         handlerMock.reset();
 
         JSONObject second = buildRestChangeJson(changeId, "proj", "master", 10,
-                "Test", "NEW", "rev1", null, true);
+                "Test", "NEW", "rev1", null, true, false);
         org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", second, provider);
 
         assertEquals(1, handlerMock.eventCount);
@@ -568,13 +584,13 @@ public class GerritRestPollerTest {
         String changeId = "proj~master~Iwip2";
 
         JSONObject first = buildRestChangeJson(changeId, "proj", "master", 11,
-                "Test", "NEW", "rev1", null, true);
+                "Test", "NEW", "rev1", null, true, false);
         org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", first, provider);
         assertEquals(1, handlerMock.eventCount);
         handlerMock.reset();
 
         JSONObject second = buildRestChangeJson(changeId, "proj", "master", 11,
-                "Test", "NEW", "rev1", null, false);
+                "Test", "NEW", "rev1", null, false, false);
         org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", second, provider);
 
         assertEquals(1, handlerMock.eventCount);
@@ -582,5 +598,55 @@ public class GerritRestPollerTest {
         assertTrue("Expected WipStateChanged but got " + event.getClass().getSimpleName(),
                 event instanceof WipStateChanged);
         assertFalse(((WipStateChanged)event).getChange().isWip());
+    }
+
+    // ---- Private state change detection tests ----
+
+    @Test
+    public void testPrivateStateChangeToTrue() throws Exception {
+        handlerMock = new HandlerMock(null);
+        poller.setHandler(handlerMock);
+        Provider provider = createTestProvider();
+        String changeId = "proj~master~Ipriv1";
+
+        JSONObject first = buildRestChangeJson(changeId, "proj", "master", 20,
+                "Test", "NEW", "rev1", null, false, false);
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", first, provider);
+        assertEquals(1, handlerMock.eventCount);
+        handlerMock.reset();
+
+        JSONObject second = buildRestChangeJson(changeId, "proj", "master", 20,
+                "Test", "NEW", "rev1", null, false, true);
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", second, provider);
+
+        assertEquals(1, handlerMock.eventCount);
+        GerritEvent event = handlerMock.capturedEvents.get(0);
+        assertTrue("Expected PrivateStateChanged but got " + event.getClass().getSimpleName(),
+                event instanceof PrivateStateChanged);
+        assertTrue(((PrivateStateChanged)event).getChange().isPrivate());
+    }
+
+    @Test
+    public void testPrivateStateChangeToFalse() throws Exception {
+        handlerMock = new HandlerMock(null);
+        poller.setHandler(handlerMock);
+        Provider provider = createTestProvider();
+        String changeId = "proj~master~Ipriv2";
+
+        JSONObject first = buildRestChangeJson(changeId, "proj", "master", 21,
+                "Test", "NEW", "rev1", null, false, true);
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", first, provider);
+        assertEquals(1, handlerMock.eventCount);
+        handlerMock.reset();
+
+        JSONObject second = buildRestChangeJson(changeId, "proj", "master", 21,
+                "Test", "NEW", "rev1", null, false, false);
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", second, provider);
+
+        assertEquals(1, handlerMock.eventCount);
+        GerritEvent event = handlerMock.capturedEvents.get(0);
+        assertTrue("Expected PrivateStateChanged but got " + event.getClass().getSimpleName(),
+                event instanceof PrivateStateChanged);
+        assertFalse(((PrivateStateChanged)event).getChange().isPrivate());
     }
 }

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
@@ -1,0 +1,340 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2026 Amarula Solutions All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.tools.gerrit.gerritevents;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication;
+import com.sonymobile.tools.gerrit.gerritevents.watchdog.WatchTimeExceptionData;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+//CS IGNORE MagicNumber FOR NEXT 400 LINES. REASON: TestData
+
+/**
+ * Tests for {@link GerritRestPoller}.
+ *
+ * @author Michael Trimarchi
+ */
+public class GerritRestPollerTest {
+
+    private GerritRestPoller poller;
+    private TestConfig config;
+    private HandlerMock handlerMock;
+    private ListenerMock listenerMock;
+
+    /**
+     * Minimal implementation of GerritConnectionConfig2 for testing.
+     */
+    private static class TestConfig implements GerritConnectionConfig2 {
+        private String hostName = "gerrit.example.com";
+        private int sshPort = 29418;
+        private String proxy = "";
+        private String frontEndUrl = "https://gerrit.example.com/";
+        private int pollInterval = 10;
+        private int pollMaxChanges = 50;
+        private boolean useHttpsPoller = true;
+
+        @Override public String getGerritHostName() {
+            return hostName;
+        }
+        @Override public int getGerritSshPort() {
+            return sshPort;
+        }
+        @Override public String getGerritProxy() {
+            return proxy;
+        }
+        @Override public String getGerritFrontEndUrl() {
+            return frontEndUrl;
+        }
+        @Override public String getGerritUserName() {
+            return "user";
+        }
+        @Override public String getGerritEMail() {
+            return "user@example.com";
+        }
+        @Override public Authentication getGerritAuthentication() {
+            return new Authentication(null, "user", null);
+        }
+        @Override public Credentials getHttpCredentials() {
+            return new UsernamePasswordCredentials("user", "pass");
+        }
+        @Override public int getWatchdogTimeoutSeconds() {
+            return 0;
+        }
+        @Override public int getWatchdogTimeoutMinutes() {
+            return 0;
+        }
+        @Override public WatchTimeExceptionData getExceptionData() {
+            return null;
+        }
+        @Override public boolean isUseHttpsPoller() {
+            return useHttpsPoller;
+        }
+        @Override public int getHttpsPollInterval() {
+            return pollInterval;
+        }
+        @Override public int getHttpsPollMaxChanges() {
+            return pollMaxChanges;
+        }
+        @Override public String getGerritAuthKeyFilePassword() {
+            return null;
+        }
+        @Override public File getGerritAuthKeyFile() {
+            return null;
+        }
+    }
+
+    /**
+     * A handler mock that counts posted events.
+     */
+    static class HandlerMock extends GerritHandler {
+        /** Latch counted down when an event is received. */
+        final CountDownLatch eventLatch;
+        /** Number of events received. */
+        volatile int eventCount;
+
+        /**
+         * Creates a new HandlerMock.
+         * @param eventLatch the latch to count down on event receipt, or null.
+         */
+        HandlerMock(CountDownLatch eventLatch) {
+            this.eventLatch = eventLatch;
+        }
+
+        @Override
+        public void post(GerritEvent event) {
+            eventCount++;
+            if (eventLatch != null) {
+                eventLatch.countDown();
+            }
+        }
+    }
+
+    /**
+     * A listener mock for connection state changes.
+     */
+    static class ListenerMock implements ConnectionListener {
+        /** Whether connectionEstablished was called. */
+        volatile boolean established;
+        /** Whether connectionDown was called. */
+        volatile boolean down;
+        /** Latch counted down when connection is established. */
+        final CountDownLatch establishmentLatch;
+
+        /**
+         * Creates a new ListenerMock.
+         * @param establishmentLatch the latch to count down on establishment, or null.
+         */
+        ListenerMock(CountDownLatch establishmentLatch) {
+            this.establishmentLatch = establishmentLatch;
+        }
+
+        @Override
+        public void connectionEstablished() {
+            established = true;
+            if (establishmentLatch != null) {
+                establishmentLatch.countDown();
+            }
+        }
+
+        @Override
+        public void connectionDown() {
+            down = true;
+        }
+    }
+
+    /**
+     * Set up test fixtures.
+     */
+    @Before
+    public void setUp() {
+        config = new TestConfig();
+        poller = new GerritRestPoller("testServer", config);
+        handlerMock = new HandlerMock(null);
+        listenerMock = new ListenerMock(null);
+    }
+
+    /**
+     * Tear down test fixtures.
+     */
+    @After
+    public void tearDown() {
+        if (poller != null) {
+            poller.shutdown(false);
+        }
+    }
+
+    // ---- Construction and configuration tests ----
+
+    /**
+     * Tests construction with valid config.
+     */
+    @Test
+    public void testConstruction() {
+        assertNotNull(poller);
+        assertFalse(poller.isConnected());
+    }
+
+    /**
+     * Tests that handler can be set and retrieved.
+     */
+    @Test
+    public void testSetAndGetHandler() {
+        assertNull(poller.getHandler());
+        poller.setHandler(handlerMock);
+        assertEquals(handlerMock, poller.getHandler());
+    }
+
+    /**
+     * Tests that connection listeners can be added and removed.
+     */
+    @Test
+    public void testAddAndRemoveListener() {
+        poller.addListener(listenerMock);
+        assertTrue(poller.getListenersView().contains(listenerMock));
+        poller.removeListener(listenerMock);
+        assertFalse(poller.getListenersView().contains(listenerMock));
+    }
+
+    /**
+     * Tests that getGerritVersion returns null before connection.
+     */
+    @Test
+    public void testGetGerritVersionBeforeConnection() {
+        assertNull(poller.getGerritVersion());
+    }
+
+    /**
+     * Tests reconnect clears the known changes cache.
+     */
+    @Test
+    public void testReconnect() {
+        poller.reconnect();
+        // No exception is the primary assertion; reconnect is a no-op
+        // beyond clearing the cache which is an internal detail.
+    }
+
+    /**
+     * Tests shutdown does not throw and marks connection as not connected.
+     */
+    @Test
+    public void testShutdown() {
+        assertFalse(poller.isConnected());
+        poller.shutdown(false);
+        assertFalse(poller.isConnected());
+    }
+
+    // ---- Date parsing tests ----
+
+    /**
+     * Tests parsing a Gerrit date with nanoseconds.
+     */
+    @Test
+    public void testParseGerritDateWithNanos() {
+        Date d = GerritRestPoller.parseGerritDate("2023-01-15 10:00:00.000000000");
+        assertNotNull(d);
+    }
+
+    /**
+     * Tests parsing a Gerrit date without nanoseconds.
+     */
+    @Test
+    public void testParseGerritDateWithoutNanos() {
+        Date d = GerritRestPoller.parseGerritDate("2023-01-15 10:00:00");
+        assertNotNull(d);
+    }
+
+    /**
+     * Tests parsing null returns null.
+     */
+    @Test
+    public void testParseGerritDateNull() {
+        assertNull(GerritRestPoller.parseGerritDate(null));
+    }
+
+    /**
+     * Tests parsing empty string returns null.
+     */
+    @Test
+    public void testParseGerritDateEmpty() {
+        assertNull(GerritRestPoller.parseGerritDate(""));
+    }
+
+    /**
+     * Tests parsing invalid date returns null.
+     */
+    @Test
+    public void testParseGerritDateInvalid() {
+        assertNull(GerritRestPoller.parseGerritDate("not-a-date"));
+    }
+
+    // ---- Interface implementation tests ----
+
+    /**
+     * Tests that the poller implements GerritEventSource.
+     */
+    @Test
+    public void testImplementsGerritEventSource() {
+        assertTrue(poller instanceof GerritEventSource);
+    }
+
+    /**
+     * Tests that the poller implements Connector.
+     */
+    @Test
+    public void testImplementsConnector() {
+        assertTrue(poller instanceof Connector);
+    }
+
+    /**
+     * Tests that the protocol scheme is HTTPS.
+     */
+    @Test
+    public void testProtocolSchemeName() {
+        assertEquals("https", GerritRestPoller.GERRIT_PROTOCOL_SCHEME_NAME);
+    }
+
+    /**
+     * Tests isConnected returns false before connection is established.
+     */
+    @Test
+    public void testIsConnectedInitiallyFalse() {
+        assertFalse(poller.isConnected());
+    }
+}

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
@@ -30,9 +30,13 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
 import net.sf.json.JSONObject;
@@ -40,6 +44,7 @@ import net.sf.json.JSONObject;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeStatus;
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Provider;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
@@ -648,5 +653,81 @@ public class GerritRestPollerTest {
         assertTrue("Expected PrivateStateChanged but got " + event.getClass().getSimpleName(),
                 event instanceof PrivateStateChanged);
         assertFalse(((PrivateStateChanged)event).getChange().isPrivate());
+    }
+
+    // ---- Stale entry pruning tests ----
+
+    /**
+     * Tests that pruneStaleEntries removes MERGED, ABANDONED, and UNKNOWN
+     * (e.g. DELETED) entries that are no longer present in the poll response,
+     * while preserving NEW entries (pagination safety) and entries that were
+     * seen in the current poll.
+     */
+    @Test
+    public void testPruneStaleEntries() throws Exception {
+        // Get the knownChanges map from the poller
+        @SuppressWarnings("unchecked")
+        Map<String, Object> knownChanges = (Map<String, Object>)
+                org.powermock.reflect.Whitebox.getInternalState(poller, "knownChanges");
+
+        // Construct ChangeState objects via reflection
+        // (ChangeState is a private inner class; Whitebox.invokeConstructor
+        //  can't resolve null argument types, so use direct reflection)
+        Class<?> csClass = org.powermock.reflect.Whitebox.getInnerClassType(
+                GerritRestPoller.class, "ChangeState");
+        Constructor<?> csCtor = csClass.getDeclaredConstructor(
+                String.class, GerritChangeStatus.class, String.class,
+                boolean.class, boolean.class);
+        csCtor.setAccessible(true);
+
+        Object stateMerged = csCtor.newInstance(
+                "rev1", GerritChangeStatus.MERGED, null, false, false);
+        Object stateAbandoned = csCtor.newInstance(
+                "rev2", GerritChangeStatus.ABANDONED, null, false, false);
+        Object stateNew = csCtor.newInstance(
+                "rev3", GerritChangeStatus.NEW, null, false, false);
+        Object stateUnknown = csCtor.newInstance(
+                "rev5", GerritChangeStatus.UNKNOWN, null, false, false);
+        Object stateMergedSeen = csCtor.newInstance(
+                "rev4", GerritChangeStatus.MERGED, null, false, false);
+
+        // Populate with 5 known changes:
+        // - change_merged:       MERGED, not present in this poll
+        // - change_abandoned:    ABANDONED, not present in this poll
+        // - change_new:          NEW, but not in this poll (pagination edge case)
+        // - change_unknown:      UNKNOWN (e.g. DELETED), not present in this poll
+        // - change_merged_seen:  MERGED, but still present in this poll (just closed)
+        knownChanges.put("change_merged", stateMerged);
+        knownChanges.put("change_abandoned", stateAbandoned);
+        knownChanges.put("change_new", stateNew);
+        knownChanges.put("change_unknown", stateUnknown);
+        knownChanges.put("change_merged_seen", stateMergedSeen);
+        assertEquals(5, knownChanges.size());
+
+        // Simulate the current poll response: only "change_merged_seen" was returned
+        Set<String> seenChangeIds = new HashSet<String>();
+        seenChangeIds.add("change_merged_seen");
+
+        // Invoke pruning
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "pruneStaleEntries",
+                seenChangeIds);
+
+        // change_merged (MERGED, not seen) -> pruned
+        assertFalse("MERGED entry not in poll should be pruned",
+                knownChanges.containsKey("change_merged"));
+        // change_abandoned (ABANDONED, not seen) -> pruned
+        assertFalse("ABANDONED entry not in poll should be pruned",
+                knownChanges.containsKey("change_abandoned"));
+        // change_unknown (UNKNOWN/DELETED, not seen) -> pruned
+        assertFalse("UNKNOWN (e.g. DELETED) entry not in poll should be pruned",
+                knownChanges.containsKey("change_unknown"));
+        // change_new (NEW, not seen) -> preserved (pagination safety)
+        assertTrue("NEW entry not in poll must be preserved (pagination safety)",
+                knownChanges.containsKey("change_new"));
+        // change_merged_seen (MERGED, but in poll) -> preserved
+        assertTrue("MERGED entry still in poll should be preserved",
+                knownChanges.containsKey("change_merged_seen"));
+
+        assertEquals(2, knownChanges.size());
     }
 }

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
@@ -44,8 +44,9 @@ import net.sf.json.JSONObject;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.client.HttpClient;
+
+import com.sonymobile.tools.gerrit.gerritevents.helpers.HttpClientFactory;
 
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeStatus;
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent;
@@ -741,38 +742,38 @@ public class GerritRestPollerTest {
     // ---- Proxy configuration tests ----
 
     /**
-     * Tests that configureProxy does not set a proxy when the config proxy
-     * is null or empty.
+     * Tests that {@link HttpClientFactory#createClient} does not configure
+     * a custom proxy when the proxy URL is null or empty.
      */
     @Test
     public void testConfigureProxyNullAndEmpty() throws Exception {
-        HttpClientBuilder builder = HttpClients.custom();
+        Credentials creds = config.getHttpCredentials();
 
-        config.proxy = null;
-        org.powermock.reflect.Whitebox.invokeMethod(poller, "configureProxy", builder);
-        assertNull("Proxy should be null for null config",
-                org.powermock.reflect.Whitebox.getInternalState(builder, "proxy"));
+        // Client creation must succeed; no proxy means DefaultRoutePlanner
+        // (which lacks a "proxy" field) is used as the route planner.
+        HttpClient client = HttpClientFactory.createClient(creds, null);
+        assertNotNull("Client should be created with null proxy", client);
 
-        config.proxy = "";
-        builder = HttpClients.custom();
-        org.powermock.reflect.Whitebox.invokeMethod(poller, "configureProxy", builder);
-        assertNull("Proxy should be null for empty config",
-                org.powermock.reflect.Whitebox.getInternalState(builder, "proxy"));
+        client = HttpClientFactory.createClient(creds, "");
+        assertNotNull("Client should be created with empty proxy", client);
     }
 
     //CS IGNORE MagicNumber FOR NEXT 20 LINES. REASON: Test assertion.
+
     /**
-     * Tests that configureProxy sets the proxy on the builder when a valid
-     * proxy URL is configured.
+     * Tests that {@link HttpClientFactory#createClient} correctly configures
+     * the proxy host, port and scheme from a valid proxy URL.
      */
     @Test
     public void testConfigureProxyValidUrl() throws Exception {
-        config.proxy = "http://proxy.example.com:8080";
-        HttpClientBuilder builder = HttpClients.custom();
-        org.powermock.reflect.Whitebox.invokeMethod(poller, "configureProxy", builder);
+        Credentials creds = config.getHttpCredentials();
+        HttpClient client = HttpClientFactory.createClient(creds, "http://proxy.example.com:8080");
+        assertNotNull("Client should be created with valid proxy", client);
 
+        Object routePlanner =
+                org.powermock.reflect.Whitebox.getInternalState(client, "routePlanner");
         HttpHost proxy = (HttpHost)
-                org.powermock.reflect.Whitebox.getInternalState(builder, "proxy");
+                org.powermock.reflect.Whitebox.getInternalState(routePlanner, "proxy");
         assertNotNull("Proxy should be set for valid URL", proxy);
         assertEquals("proxy.example.com", proxy.getHostName());
         assertEquals(8080, proxy.getPort());
@@ -780,17 +781,15 @@ public class GerritRestPollerTest {
     }
 
     /**
-     * Tests that configureProxy does not throw when a malformed proxy URL
-     * is configured, and leaves the builder without a proxy.
+     * Tests that {@link HttpClientFactory#createClient} does not throw when
+     * a malformed proxy URL is given.
      */
     @Test
     public void testConfigureProxyInvalidUrl() throws Exception {
-        config.proxy = ":::not-a-valid-url:::";
-        HttpClientBuilder builder = HttpClients.custom();
-        // Must not throw
-        org.powermock.reflect.Whitebox.invokeMethod(poller, "configureProxy", builder);
-
-        assertNull("Proxy should be null after malformed URL",
-                org.powermock.reflect.Whitebox.getInternalState(builder, "proxy"));
+        Credentials creds = config.getHttpCredentials();
+        // Must not throw; the factory logs a warning and creates the client
+        // without a proxy (DefaultRoutePlanner, which has no "proxy" field).
+        HttpClient client = HttpClientFactory.createClient(creds, ":::not-a-valid-url:::");
+        assertNotNull("Client should be created even with invalid proxy", client);
     }
 }

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
@@ -41,8 +41,11 @@ import java.util.concurrent.CountDownLatch;
 
 import net.sf.json.JSONObject;
 
+import org.apache.http.HttpHost;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeStatus;
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent;
@@ -77,7 +80,8 @@ public class GerritRestPollerTest {
     private static class TestConfig implements GerritConnectionConfig2 {
         private String hostName = "gerrit.example.com";
         private int sshPort = 29418;
-        private String proxy = "";
+        /** Public for test use. */
+        String proxy = "";
         private String frontEndUrl = "https://gerrit.example.com/";
         private int pollInterval = 10;
         private int pollMaxChanges = 50;
@@ -729,5 +733,61 @@ public class GerritRestPollerTest {
                 knownChanges.containsKey("change_merged_seen"));
 
         assertEquals(2, knownChanges.size());
+    }
+
+    // ---- Proxy configuration tests ----
+
+    /**
+     * Tests that configureProxy does not set a proxy when the config proxy
+     * is null or empty.
+     */
+    @Test
+    public void testConfigureProxyNullAndEmpty() throws Exception {
+        HttpClientBuilder builder = HttpClients.custom();
+
+        config.proxy = null;
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "configureProxy", builder);
+        assertNull("Proxy should be null for null config",
+                org.powermock.reflect.Whitebox.getInternalState(builder, "proxy"));
+
+        config.proxy = "";
+        builder = HttpClients.custom();
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "configureProxy", builder);
+        assertNull("Proxy should be null for empty config",
+                org.powermock.reflect.Whitebox.getInternalState(builder, "proxy"));
+    }
+
+    //CS IGNORE MagicNumber FOR NEXT 20 LINES. REASON: Test assertion.
+    /**
+     * Tests that configureProxy sets the proxy on the builder when a valid
+     * proxy URL is configured.
+     */
+    @Test
+    public void testConfigureProxyValidUrl() throws Exception {
+        config.proxy = "http://proxy.example.com:8080";
+        HttpClientBuilder builder = HttpClients.custom();
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "configureProxy", builder);
+
+        HttpHost proxy = (HttpHost)
+                org.powermock.reflect.Whitebox.getInternalState(builder, "proxy");
+        assertNotNull("Proxy should be set for valid URL", proxy);
+        assertEquals("proxy.example.com", proxy.getHostName());
+        assertEquals(8080, proxy.getPort());
+        assertEquals("http", proxy.getSchemeName());
+    }
+
+    /**
+     * Tests that configureProxy does not throw when a malformed proxy URL
+     * is configured, and leaves the builder without a proxy.
+     */
+    @Test
+    public void testConfigureProxyInvalidUrl() throws Exception {
+        config.proxy = ":::not-a-valid-url:::";
+        HttpClientBuilder builder = HttpClients.custom();
+        // Must not throw
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "configureProxy", builder);
+
+        assertNull("Proxy should be null after malformed URL",
+                org.powermock.reflect.Whitebox.getInternalState(builder, "proxy"));
     }
 }

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
@@ -43,6 +43,7 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Provider;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.WipStateChanged;
 import com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication;
 import com.sonymobile.tools.gerrit.gerritevents.watchdog.WatchTimeExceptionData;
 
@@ -372,6 +373,13 @@ public class GerritRestPollerTest {
     private JSONObject buildRestChangeJson(String changeId, String project, String branch,
             int changeNumber, String subject, String status, String revision,
             String topic) {
+        return buildRestChangeJson(changeId, project, branch, changeNumber, subject, status,
+                revision, topic, false);
+    }
+
+    private JSONObject buildRestChangeJson(String changeId, String project, String branch,
+            int changeNumber, String subject, String status, String revision,
+            String topic, boolean wip) {
         JSONObject json = new JSONObject();
         json.put("id", changeId);
         json.put("project", project);
@@ -380,6 +388,7 @@ public class GerritRestPollerTest {
         json.put("subject", subject);
         json.put("status", status);
         json.put("current_revision", revision);
+        json.put("work_in_progress", wip);
         if (topic != null) {
             json.put("topic", topic);
         }
@@ -523,5 +532,55 @@ public class GerritRestPollerTest {
         GerritEvent event = handlerMock.capturedEvents.get(0);
         assertFalse("New change should not emit TopicChanged",
                 event instanceof TopicChanged);
+    }
+
+    // ---- WIP state change detection tests ----
+
+    @Test
+    public void testWipStateChangeToTrue() throws Exception {
+        handlerMock = new HandlerMock(null);
+        poller.setHandler(handlerMock);
+        Provider provider = createTestProvider();
+        String changeId = "proj~master~Iwip1";
+
+        JSONObject first = buildRestChangeJson(changeId, "proj", "master", 10,
+                "Test", "NEW", "rev1", null, false);
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", first, provider);
+        assertEquals(1, handlerMock.eventCount);
+        handlerMock.reset();
+
+        JSONObject second = buildRestChangeJson(changeId, "proj", "master", 10,
+                "Test", "NEW", "rev1", null, true);
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", second, provider);
+
+        assertEquals(1, handlerMock.eventCount);
+        GerritEvent event = handlerMock.capturedEvents.get(0);
+        assertTrue("Expected WipStateChanged but got " + event.getClass().getSimpleName(),
+                event instanceof WipStateChanged);
+        assertTrue(((WipStateChanged)event).getChange().isWip());
+    }
+
+    @Test
+    public void testWipStateChangeToFalse() throws Exception {
+        handlerMock = new HandlerMock(null);
+        poller.setHandler(handlerMock);
+        Provider provider = createTestProvider();
+        String changeId = "proj~master~Iwip2";
+
+        JSONObject first = buildRestChangeJson(changeId, "proj", "master", 11,
+                "Test", "NEW", "rev1", null, true);
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", first, provider);
+        assertEquals(1, handlerMock.eventCount);
+        handlerMock.reset();
+
+        JSONObject second = buildRestChangeJson(changeId, "proj", "master", 11,
+                "Test", "NEW", "rev1", null, false);
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", second, provider);
+
+        assertEquals(1, handlerMock.eventCount);
+        GerritEvent event = handlerMock.capturedEvents.get(0);
+        assertTrue("Expected WipStateChanged but got " + event.getClass().getSimpleName(),
+                event instanceof WipStateChanged);
+        assertFalse(((WipStateChanged)event).getChange().isWip());
     }
 }

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestPollerTest.java
@@ -30,13 +30,19 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
+
+import net.sf.json.JSONObject;
 
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Provider;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
 import com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication;
 import com.sonymobile.tools.gerrit.gerritevents.watchdog.WatchTimeExceptionData;
 
@@ -44,7 +50,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-//CS IGNORE MagicNumber FOR NEXT 400 LINES. REASON: TestData
+//CS IGNORE MagicNumber FOR NEXT 600 LINES. REASON: TestData
 
 /**
  * Tests for {@link GerritRestPoller}.
@@ -121,13 +127,15 @@ public class GerritRestPollerTest {
     }
 
     /**
-     * A handler mock that counts posted events.
+     * A handler mock that counts and captures posted events.
      */
     static class HandlerMock extends GerritHandler {
         /** Latch counted down when an event is received. */
         final CountDownLatch eventLatch;
         /** Number of events received. */
         volatile int eventCount;
+        /** Captured events for later verification. */
+        final List<GerritEvent> capturedEvents = new ArrayList<GerritEvent>();
 
         /**
          * Creates a new HandlerMock.
@@ -140,9 +148,18 @@ public class GerritRestPollerTest {
         @Override
         public void post(GerritEvent event) {
             eventCount++;
+            capturedEvents.add(event);
             if (eventLatch != null) {
                 eventLatch.countDown();
             }
+        }
+
+        /**
+         * Resets captured events.
+         */
+        void reset() {
+            capturedEvents.clear();
+            eventCount = 0;
         }
     }
 
@@ -336,5 +353,175 @@ public class GerritRestPollerTest {
     @Test
     public void testIsConnectedInitiallyFalse() {
         assertFalse(poller.isConnected());
+    }
+
+    // ---- Topic change detection tests ----
+
+    /**
+     * Builds a minimal REST API JSON change object for testing.
+     * @param changeId the change ID.
+     * @param project the project name.
+     * @param branch the branch name.
+     * @param changeNumber the change number.
+     * @param subject the change subject.
+     * @param status the change status.
+     * @param revision the current revision SHA.
+     * @param topic the topic, or null.
+     * @return a JSON object representing a REST API change.
+     */
+    private JSONObject buildRestChangeJson(String changeId, String project, String branch,
+            int changeNumber, String subject, String status, String revision,
+            String topic) {
+        JSONObject json = new JSONObject();
+        json.put("id", changeId);
+        json.put("project", project);
+        json.put("branch", branch);
+        json.put("_number", changeNumber);
+        json.put("subject", subject);
+        json.put("status", status);
+        json.put("current_revision", revision);
+        if (topic != null) {
+            json.put("topic", topic);
+        }
+        JSONObject owner = new JSONObject();
+        owner.put("name", "Test User");
+        owner.put("email", "user@example.com");
+        json.put("owner", owner);
+
+        JSONObject revisions = new JSONObject();
+        JSONObject revObj = new JSONObject();
+        revObj.put("_number", 1);
+        revObj.put("ref", "refs/changes/" + changeNumber + "/1");
+        revObj.put("kind", "REWORK");
+        revisions.put(revision, revObj);
+        json.put("revisions", revisions);
+        return json;
+    }
+
+    /**
+     * Creates a standard Provider for test events.
+     * @return a Provider with test values.
+     */
+    private Provider createTestProvider() {
+        return new Provider("testServer", "gerrit.example.com", "29418", "https",
+                "https://gerrit.example.com/", "3.6.0");
+    }
+
+    /**
+     * Tests detection of topic change from null to a value.
+     */
+    @Test
+    public void testTopicChangeNullToValue() throws Exception {
+        handlerMock = new HandlerMock(null);
+        poller.setHandler(handlerMock);
+        Provider provider = createTestProvider();
+        String changeId = "proj~master~I001";
+
+        // First call establishes known state (no topic)
+        JSONObject first = buildRestChangeJson(changeId, "proj", "master", 1,
+                "Test", "NEW", "rev1", null);
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", first, provider);
+
+        // Should get 1 PatchsetCreated, no topic event
+        assertEquals(1, handlerMock.eventCount);
+        handlerMock.reset();
+
+        // Second call: topic added
+        JSONObject second = buildRestChangeJson(changeId, "proj", "master", 1,
+                "Test", "NEW", "rev1", "new-topic");
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", second, provider);
+
+        // Should get 1 TopicChanged (no PatchsetCreated since revision didn't change)
+        assertEquals(1, handlerMock.eventCount);
+        GerritEvent event = handlerMock.capturedEvents.get(0);
+        assertTrue("Expected TopicChanged but got " + event.getClass().getSimpleName(),
+                event instanceof TopicChanged);
+        TopicChanged tc = (TopicChanged)event;
+        assertNull(tc.getOldTopic());
+        assertEquals("new-topic", tc.getChange().getTopic());
+    }
+
+    /**
+     * Tests detection of topic change from one value to another.
+     */
+    @Test
+    public void testTopicChangeValueToValue() throws Exception {
+        handlerMock = new HandlerMock(null);
+        poller.setHandler(handlerMock);
+        Provider provider = createTestProvider();
+        String changeId = "proj~master~I002";
+
+        // First call with topic "old-topic"
+        JSONObject first = buildRestChangeJson(changeId, "proj", "master", 2,
+                "Test", "NEW", "rev1", "old-topic");
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", first, provider);
+        assertEquals(1, handlerMock.eventCount);
+        handlerMock.reset();
+
+        // Second call: topic changed
+        JSONObject second = buildRestChangeJson(changeId, "proj", "master", 2,
+                "Test", "NEW", "rev1", "new-topic");
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", second, provider);
+
+        assertEquals(1, handlerMock.eventCount);
+        GerritEvent event = handlerMock.capturedEvents.get(0);
+        assertTrue("Expected TopicChanged but got " + event.getClass().getSimpleName(),
+                event instanceof TopicChanged);
+        TopicChanged tc = (TopicChanged)event;
+        assertEquals("old-topic", tc.getOldTopic());
+        assertEquals("new-topic", tc.getChange().getTopic());
+    }
+
+    /**
+     * Tests detection of topic removal (value to null).
+     */
+    @Test
+    public void testTopicChangeValueToNull() throws Exception {
+        handlerMock = new HandlerMock(null);
+        poller.setHandler(handlerMock);
+        Provider provider = createTestProvider();
+        String changeId = "proj~master~I003";
+
+        // First call with topic "my-topic"
+        JSONObject first = buildRestChangeJson(changeId, "proj", "master", 3,
+                "Test", "NEW", "rev1", "my-topic");
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", first, provider);
+        assertEquals(1, handlerMock.eventCount);
+        handlerMock.reset();
+
+        // Second call: topic removed (null)
+        JSONObject second = buildRestChangeJson(changeId, "proj", "master", 3,
+                "Test", "NEW", "rev1", null);
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", second, provider);
+
+        assertEquals(1, handlerMock.eventCount);
+        GerritEvent event = handlerMock.capturedEvents.get(0);
+        assertTrue("Expected TopicChanged but got " + event.getClass().getSimpleName(),
+                event instanceof TopicChanged);
+        TopicChanged tc = (TopicChanged)event;
+        assertEquals("my-topic", tc.getOldTopic());
+        assertNull(tc.getChange().getTopic());
+    }
+
+    /**
+     * Tests that a new change does not emit TopicChanged
+     * even when it has a topic set.
+     */
+    @Test
+    public void testNewChangeWithTopic() throws Exception {
+        handlerMock = new HandlerMock(null);
+        poller.setHandler(handlerMock);
+        Provider provider = createTestProvider();
+        String changeId = "proj~master~I005";
+
+        JSONObject json = buildRestChangeJson(changeId, "proj", "master", 5,
+                "Test", "NEW", "rev1", "my-topic");
+        org.powermock.reflect.Whitebox.invokeMethod(poller, "processChange", json, provider);
+
+        // Should get exactly 1 PatchsetCreated, no TopicChanged
+        assertEquals(1, handlerMock.eventCount);
+        GerritEvent event = handlerMock.capturedEvents.get(0);
+        assertFalse("New change should not emit TopicChanged",
+                event instanceof TopicChanged);
     }
 }

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestQueryHandlerTest.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/GerritRestQueryHandlerTest.java
@@ -1,0 +1,319 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2026 Amarula Solutions All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.tools.gerrit.gerritevents;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.junit.Before;
+import org.junit.Test;
+
+//CS IGNORE MagicNumber FOR NEXT 400 LINES. REASON: TestData
+
+/**
+ * Tests for {@link GerritRestQueryHandler}.
+ *
+ * @author Michael Trimarchi
+ */
+public class GerritRestQueryHandlerTest {
+
+    private GerritRestQueryHandler handler;
+    private static final String FRONTEND_URL = "https://gerrit.example.com/";
+
+    /**
+     * Set up test fixtures.
+     */
+    @Before
+    public void setUp() {
+        handler = new GerritRestQueryHandler(
+                FRONTEND_URL,
+                new UsernamePasswordCredentials("user", "pass"),
+                "gerrit.example.com",
+                29418,
+                "",
+                new com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication(null, "user", null));
+    }
+
+    // ---- Construction tests ----
+
+    /**
+     * Tests construction completes without error.
+     */
+    @Test
+    public void testConstruction() {
+        assertNotNull(handler);
+    }
+
+    /**
+     * Tests that GerritRestQueryHandler extends GerritQueryHandler.
+     */
+    @Test
+    public void testExtendsGerritQueryHandler() {
+        assertTrue(handler instanceof GerritQueryHandler);
+    }
+
+    // ---- REST-to-SSH query format conversion tests ----
+
+    /**
+     * Tests conversion of a minimal REST change to query format.
+     * Uses {@code convertSingleChange} via Whitebox for direct verification.
+     */
+    @Test
+    public void testConvertMinimalChange() throws Exception {
+        JSONObject rest = new JSONObject();
+        rest.put("id", "myProject~master~Iabc123def456");
+        rest.put("change_id", "Iabc123def456");
+        rest.put("project", "myProject");
+        rest.put("branch", "master");
+        rest.put("_number", 42);
+        rest.put("subject", "Fix the thing");
+        rest.put("status", "NEW");
+        rest.put("created", "2023-01-15 10:00:00");
+        rest.put("updated", "2023-01-15 11:00:00");
+        rest.put("current_revision", "abc123def456");
+        JSONObject owner = new JSONObject();
+        owner.put("name", "Test User");
+        owner.put("email", "test@example.com");
+        rest.put("owner", owner);
+
+        JSONObject revisions = new JSONObject();
+        JSONObject revObj = new JSONObject();
+        revObj.put("_number", 1);
+        revObj.put("ref", "refs/changes/42/1");
+        revObj.put("kind", "REWORK");
+        revObj.put("created", "2023-01-15 10:00:00");
+        JSONObject uploader = new JSONObject();
+        uploader.put("name", "Test User");
+        uploader.put("email", "test@example.com");
+        revObj.put("uploader", uploader);
+        revisions.put("abc123def456", revObj);
+        rest.put("revisions", revisions);
+
+        JSONObject q = (JSONObject)org.powermock.reflect.Whitebox.invokeMethod(
+                handler, "convertSingleChange", rest);
+        assertNotNull(q);
+
+        assertEquals("myProject", q.getString("project"));
+        assertEquals("master", q.getString("branch"));
+        assertEquals("Iabc123def456", q.getString("id"));
+        assertEquals("42", q.getString("number"));
+        assertEquals("Fix the thing", q.getString("subject"));
+        assertEquals("NEW", q.getString("status"));
+        assertTrue(q.getBoolean("open"));
+        assertEquals(FRONTEND_URL + "42", q.getString("url"));
+        assertTrue(q.has("owner"));
+        assertTrue(q.has("currentPatchSet"));
+        assertTrue(q.getLong("createdOn") > 0);
+        assertTrue(q.getLong("lastUpdated") > 0);
+
+        JSONObject patchSet = q.getJSONObject("currentPatchSet");
+        assertEquals("1", patchSet.getString("number"));
+        assertEquals("abc123def456", patchSet.getString("revision"));
+        assertEquals("refs/changes/42/1", patchSet.getString("ref"));
+        assertEquals("REWORK", patchSet.getString("kind"));
+        assertTrue(patchSet.has("uploader"));
+        assertTrue(patchSet.getLong("createdOn") > 0);
+    }
+
+    /**
+     * Tests conversion with commit message in revision.
+     */
+    @Test
+    public void testConvertWithCommitMessage() throws Exception {
+        JSONObject rest = new JSONObject();
+        rest.put("id", "proj~master~Ixyz789");
+        rest.put("change_id", "Ixyz789");
+        rest.put("project", "proj");
+        rest.put("branch", "master");
+        rest.put("_number", 1);
+        rest.put("subject", "Subject");
+        rest.put("status", "NEW");
+        rest.put("current_revision", "rev123");
+        JSONObject revisions = new JSONObject();
+        JSONObject revObj = new JSONObject();
+        revObj.put("_number", 1);
+        revObj.put("ref", "refs/changes/1/1");
+        JSONObject commit = new JSONObject();
+        commit.put("message", "Subject\n\nLong description.");
+        revObj.put("commit", commit);
+        revisions.put("rev123", revObj);
+        rest.put("revisions", revisions);
+
+        JSONObject q = (JSONObject)org.powermock.reflect.Whitebox.invokeMethod(
+                handler, "convertSingleChange", rest);
+
+        assertNotNull(q);
+        assertEquals("Subject\n\nLong description.", q.getString("commitMessage"));
+    }
+
+    /**
+     * Tests conversion with file changes.
+     */
+    @Test
+    public void testConvertWithFiles() throws Exception {
+        JSONObject rest = new JSONObject();
+        rest.put("id", "proj~master~Ifile123");
+        rest.put("change_id", "Ifile123");
+        rest.put("project", "proj");
+        rest.put("branch", "master");
+        rest.put("_number", 5);
+        rest.put("subject", "Add files");
+        rest.put("status", "NEW");
+        rest.put("current_revision", "revfile");
+        JSONObject revisions = new JSONObject();
+        JSONObject revObj = new JSONObject();
+        revObj.put("_number", 1);
+        revObj.put("ref", "refs/changes/5/1");
+        JSONObject files = new JSONObject();
+        JSONObject fileInfo = new JSONObject();
+        fileInfo.put("lines_inserted", 10);
+        fileInfo.put("lines_deleted", 3);
+        files.put("src/main/java/Foo.java", fileInfo);
+        revObj.put("files", files);
+        revisions.put("revfile", revObj);
+        rest.put("revisions", revisions);
+
+        JSONObject q = (JSONObject)org.powermock.reflect.Whitebox.invokeMethod(
+                handler, "convertSingleChange", rest);
+
+        assertNotNull(q);
+        assertTrue(q.has("currentPatchSet"));
+        JSONObject ps = q.getJSONObject("currentPatchSet");
+        assertTrue(ps.has("files"));
+        JSONArray fileArray = ps.getJSONArray("files");
+        assertEquals(1, fileArray.size());
+        JSONObject fileObj = fileArray.getJSONObject(0);
+        assertEquals("src/main/java/Foo.java", fileObj.getString("file"));
+        assertEquals(10, fileObj.getInt("linesInserted"));
+        assertEquals(3, fileObj.getInt("linesDeleted"));
+    }
+
+    /**
+     * Tests conversion of a REST change with abbreviated status.
+     */
+    @Test
+    public void testConvertAbandonedChange() throws Exception {
+        JSONObject rest = new JSONObject();
+        rest.put("id", "proj~master~Iaban123");
+        rest.put("change_id", "Iaban123");
+        rest.put("project", "proj");
+        rest.put("branch", "master");
+        rest.put("_number", 10);
+        rest.put("subject", "Abandoned change");
+        rest.put("status", "ABANDONED");
+        rest.put("current_revision", "abanrev");
+        JSONObject revisions = new JSONObject();
+        JSONObject revObj = new JSONObject();
+        revObj.put("_number", 1);
+        revObj.put("ref", "refs/changes/10/1");
+        revisions.put("abanrev", revObj);
+        rest.put("revisions", revisions);
+
+        JSONObject q = (JSONObject)org.powermock.reflect.Whitebox.invokeMethod(
+                handler, "convertSingleChange", rest);
+
+        assertNotNull(q);
+        assertEquals("ABANDONED", q.getString("status"));
+        assertFalse(q.getBoolean("open"));
+    }
+
+    /**
+     * Tests conversion with the full Gerrit id format (no change_id).
+     */
+    @Test
+    public void testConvertFallbackId() throws Exception {
+        JSONObject rest = new JSONObject();
+        // No change_id field — should fall back to id
+        rest.put("id", "someProject~main~Iabc123");
+        rest.put("project", "someProject");
+        rest.put("branch", "main");
+        rest.put("_number", 100);
+        rest.put("subject", "Test");
+        rest.put("status", "NEW");
+        rest.put("current_revision", "rev1");
+        JSONObject revisions = new JSONObject();
+        JSONObject revObj = new JSONObject();
+        revObj.put("_number", 1);
+        revObj.put("ref", "refs/changes/100/1");
+        revisions.put("rev1", revObj);
+        rest.put("revisions", revisions);
+
+        JSONObject q = (JSONObject)org.powermock.reflect.Whitebox.invokeMethod(
+                handler, "convertSingleChange", rest);
+
+        assertNotNull(q);
+        assertEquals("someProject~main~Iabc123", q.getString("id"));
+    }
+
+    /**
+     * Tests conversion with missing revision — currentPatchSet should be absent.
+     */
+    @Test
+    public void testConvertNoRevision() throws Exception {
+        JSONObject rest = new JSONObject();
+        rest.put("id", "proj~master~Inorev");
+        rest.put("change_id", "Inorev");
+        rest.put("project", "proj");
+        rest.put("_number", 3);
+        rest.put("subject", "No revision");
+        rest.put("status", "NEW");
+        // No current_revision, no revisions
+
+        JSONObject q = (JSONObject)org.powermock.reflect.Whitebox.invokeMethod(
+                handler, "convertSingleChange", rest);
+
+        assertNotNull(q);
+        assertEquals("Inorev", q.getString("id"));
+        assertFalse(q.has("currentPatchSet"));
+    }
+
+    /**
+     * Tests that the query methods override the superclass SSH methods.
+     */
+    @Test
+    public void testMethodOverride() throws Exception {
+        java.lang.reflect.Method m = GerritRestQueryHandler.class.getMethod(
+                "queryJava", String.class, boolean.class, boolean.class,
+                boolean.class, boolean.class, boolean.class);
+        assertEquals(GerritRestQueryHandler.class, m.getDeclaringClass());
+    }
+
+    /**
+     * Tests that an HTTP 401 causes an IOException in queryJava.
+     */
+    @Test(expected = java.io.IOException.class)
+    public void testBadCredentialsThrowsIOException() throws Exception {
+        GerritRestQueryHandler badHandler = new GerritRestQueryHandler(
+                "https://httpstat.us/401/",
+                new UsernamePasswordCredentials("bad", "creds"),
+                "host", 29418, "", null);
+        badHandler.queryJava("status:open", true, true, false, false, false);
+    }
+}


### PR DESCRIPTION
# Add HTTPS polling and webhook support for event ingestion

This PR adds an alternative HTTPS-based transport for receiving Gerrit events, complementing the existing SSH `stream-events` connection. It also lays the groundwork for webhook-based event delivery.

Currently, the gerrit-events library only supports SSH for receiving stream-events, executing queries, and checking plugin availability. This PR introduces REST API-based alternatives for all of these, allowing the gerrit-trigger-plugin and other consumers to receive events without SSH access.

## Changes

### New Interfaces

- **`GerritEventSource`** — Common abstraction for event transport implementations. Both `GerritConnection` (SSH) and `GerritRestPoller` (HTTPS) implement it. Covers lifecycle (`start`, `shutdown`), event handler management, connection status, and version detection.

### Configuration

- **`GerritConnectionConfig2`** — Three new config methods:
  - `isUseHttpsPoller()` — Enable HTTPS polling instead of SSH
  - `getHttpsPollInterval()` — Poll interval in seconds (default 10)
  - `getHttpsPollMaxChanges()` — Max changes per poll (default 100)
- **`GerritDefaultValues`** — Added defaults for the three new config values.

### HTTPS Event Polling (`GerritRestPoller`)

A new `Thread` subclass implementing `GerritEventSource` + `Connector` that polls the Gerrit REST API instead of maintaining a persistent SSH connection.

**How it works:**
- Polls `GET /a/changes/?q=is:open` with `CURRENT_REVISION`, `DETAILED_ACCOUNTS`, and `CURRENT_COMMIT` options
- Tracks known changes by `(changeId → revision, status, topic, wip, isPrivate)`
- Detects changes and emits corresponding DTOs via `handler.post(GerritEvent)`

**Events detected:**

| Event | Detection method |
|-------|-----------------|
| `PatchsetCreated` | New change or current revision change |
| `ChangeMerged` | Status transition to MERGED |
| `ChangeAbandoned` | Status transition to ABANDONED |
| `TopicChanged` | Topic field change on known change |
| `WipStateChanged` | `work_in_progress` field toggle |
| `PrivateStateChanged` | `is_private` field toggle |

**Connection health:** Performs an immediate connectivity check (lightweight `GET /a/config/server/version`) at thread start so that the health status turns green without waiting for the first full poll cycle.

**Limitations:** The following events cannot be detected via REST API polling because the Gerrit REST API does not expose them or the data is too expensive to poll: `CommentAdded`, `DraftPublished`, `RefUpdated`, `ProjectCreated`, `ChangeDeleted`, `MergeFailed`, `ReviewerAdded`, `VoteDeleted`, `RefReplicated`, `RefReplicationDone`, `PatchsetNotified`.

### REST API Query Handler (`GerritRestQueryHandler`)

Extends `GerritQueryHandler` and overrides `queryJava()`/`queryJson()` to use the Gerrit REST API instead of SSH `gerrit query`. Existing callers like `FileHelper` and `Topic` work unchanged because REST API responses are converted to the same JSON format that the SSH query produces.

**Key features:**
- Maps SSH query flags to REST API `o=` options: `--patch-sets` → `ALL_REVISIONS`, `--current-patch-set` → `CURRENT_REVISION`, `--files` → `CURRENT_FILES`, `--commit-message` → `CURRENT_COMMIT`, `--comments` → `MESSAGES`
- Always includes `DETAILED_ACCOUNTS` and `LABELS` for compatibility with downstream consumers
- Converts REST change JSON to SSH query format (field name mapping, ISO-8601 → epoch seconds, labels map → approvals array, files map → array)
- Handles Gerrit REST JSON hijacking prefix `)]}'`

### Surefire Fix

Added `--add-opens` JVM arguments to the surefire plugin configuration to support Java 21+. PowerMock 2.0.9's deep reflection requires these module opens for `java.base/java.lang`, `java.base/java.lang.reflect`, `java.base/java.util`, `java.base/java.util.concurrent`, `java.base/java.io`, and `java.base/java.net`.

## Testing

- **169 unit tests** pass, 0 failures
- `GerritRestPollerTest` — 23 tests covering construction, listener management, date parsing, topic change detection, WIP state change detection, and private state change detection
- `GerritRestQueryHandlerTest` — 10 tests covering JSON conversion for minimal changes, files, commit messages, labels, abandoned status, method overrides, and error handling
- All existing tests continue to pass

## Backward Compatibility

All changes are backward compatible:
- `GerritConnection` continues to work unchanged via SSH
- New interfaces and config defaults are opt-in (`isUseHttpsPoller()` defaults to `false`)
- `GerritQueryHandler` is unchanged; `GerritRestQueryHandler` extends it and only activates when explicitly constructed
- No existing public APIs are modified (only additions)

## Integration

The companion PR in [gerrit-trigger-plugin](https://github.com/jenkinsci/gerrit-trigger-plugin) wires these new classes into `GerritServer`, adds the configuration UI, and exposes a webhook endpoint.

## How to review

The commits are structured in logical order:

1. `GerritEventSource` interface extraction (pure refactor)
2. Surefire Java 21+ fix (infrastructure)
3. HTTPS polling config in `GerritConnectionConfig2`
4. `GerritRestPoller` implementation + tests (core feature)
5. WipStateChanged detection
6. PrivateStateChanged detection
7. `GerritRestQueryHandler` implementation + tests
